### PR TITLE
Add context management strategy analysis for review mode

### DIFF
--- a/docs/review-mode-context-strategy.md
+++ b/docs/review-mode-context-strategy.md
@@ -1,6 +1,25 @@
 # Review Mode: Context Management Strategy
 
-## Problem Statement
+## UPDATED: Agent-Driven Approach
+
+**Status:** This document has been superseded by the decision to use an **agent-driven review approach** with **full note content**.
+
+**New approach (see revised prototype spec):**
+- Agent receives **full content** of all notes due for review (no truncation)
+- Agent autonomously chooses review strategy
+- Tool-based context fetching (agent pulls additional context as needed)
+- Estimated cost: ~$0.07/session with Sonnet (very affordable)
+
+**This document remains as reference** for the analysis that led to the decision, but the recommended MVP strategy is now:
+- **Include full main note content** - no truncation
+- **Agent-driven prompts** - no predetermined categories
+- **On-demand tool calls** - fetch related notes only if agent needs them
+
+See `review-mode-prototype.md` for the current specification.
+
+---
+
+## Original Problem Statement
 
 The review mode requires AI to generate synthesis prompts and analyze user responses. This involves accessing note content from potentially large knowledge graphs. We **cannot** simply dump all related notes into the LLM context window because:
 
@@ -11,6 +30,8 @@ The review mode requires AI to generate synthesis prompts and analyze user respo
 5. **Scale** - User vaults may have hundreds or thousands of notes
 
 We need a smart context management strategy that provides enough information for high-quality prompts while staying within practical limits.
+
+**UPDATE:** After analysis, we determined that including full note content is both feasible and necessary for quality prompts. Cost is acceptable (~$0.07/session).
 
 ## Current Approach in Prototype Spec
 

--- a/docs/review-mode-context-strategy.md
+++ b/docs/review-mode-context-strategy.md
@@ -1,0 +1,736 @@
+# Review Mode: Context Management Strategy
+
+## Problem Statement
+
+The review mode requires AI to generate synthesis prompts and analyze user responses. This involves accessing note content from potentially large knowledge graphs. We **cannot** simply dump all related notes into the LLM context window because:
+
+1. **Token limits** - Context windows have limits (even with large models)
+2. **Cost** - More tokens = more expensive API calls
+3. **Performance** - Larger contexts = slower responses
+4. **Relevance** - Including too much context reduces signal-to-noise ratio
+5. **Scale** - User vaults may have hundreds or thousands of notes
+
+We need a smart context management strategy that provides enough information for high-quality prompts while staying within practical limits.
+
+## Current Approach in Prototype Spec
+
+The prototype spec (lines 554-564) proposes:
+
+```typescript
+context: {
+  mainNote: {
+    title: note.title,
+    summary: extractSummary(note.content, maxLength: 200)
+  },
+  relatedNotes: relatedNotes.map(n => ({
+    title: n.title,
+    summary: extractSummary(n.content, maxLength: 200),
+    relationship: n.linkType || 'related'
+  }))
+}
+```
+
+**Analysis:**
+- 200 characters per note ≈ 30-50 tokens
+- For main note + 2-3 related notes = ~150-200 tokens of context
+- Very conservative, minimal cost
+- **Risk**: May be too little context for meaningful synthesis prompts
+
+## Context Requirements by Operation
+
+### 1. Generating Synthesis Prompts
+
+**What we need:**
+- Main note: Enough content to understand core concept
+- Related notes (2-3): Enough to identify connections
+- Metadata: Titles, tags, relationships
+
+**What we DON'T need:**
+- Full text of all notes
+- Unrelated notes
+- Historical versions
+- User's entire vault
+
+**Estimated token budget:** 2,000-4,000 tokens for context
+
+### 2. Analyzing User Responses
+
+**What we need:**
+- The prompt that was asked
+- User's typed response
+- Main note content (to compare understanding)
+- Related notes mentioned in the prompt
+
+**What we DON'T need:**
+- Other notes in vault
+- Full backlink context
+- Note history
+
+**Estimated token budget:** 3,000-5,000 tokens for context
+
+## Strategy Options
+
+### Option 1: Simple Truncation (Current Prototype Approach)
+
+**How it works:**
+- Extract first N characters from each note
+- Fixed limit (e.g., 200 characters)
+
+```typescript
+function extractSummary(content: string, maxLength: number): string {
+  return content.slice(0, maxLength);
+}
+```
+
+**Pros:**
+- Dead simple to implement
+- Predictable token usage
+- Very fast
+- No additional AI calls
+
+**Cons:**
+- May cut off mid-sentence
+- Might miss key information if it's not at the start
+- No intelligence about what's important
+- 200 chars might be too short for synthesis
+
+**Cost:** Near zero overhead
+
+**Recommendation:** Good for MVP, but may need adjustment
+
+### Option 2: Intelligent Truncation (Start + End)
+
+**How it works:**
+- Take first N characters + last N/2 characters
+- Gives both introduction and conclusion
+
+```typescript
+function extractSummary(content: string, maxLength: number): string {
+  if (content.length <= maxLength) return content;
+
+  const startChars = Math.floor(maxLength * 0.7);
+  const endChars = maxLength - startChars - 3; // 3 for "..."
+
+  return content.slice(0, startChars) +
+         "..." +
+         content.slice(-endChars);
+}
+```
+
+**Pros:**
+- Better than just start
+- Captures conclusions/summaries often at end
+- Still very fast
+
+**Cons:**
+- Middle content lost
+- Still no intelligence about importance
+
+**Cost:** Near zero overhead
+
+**Recommendation:** Slight improvement over Option 1
+
+### Option 3: Markdown-Aware Summary
+
+**How it works:**
+- Parse markdown structure
+- Prioritize: title → headings → first paragraph under each heading
+- Build hierarchical summary
+
+```typescript
+function extractMarkdownSummary(content: string, maxTokens: number): string {
+  const parsed = parseMarkdown(content);
+  let summary = '';
+  let tokens = 0;
+
+  // Add title/h1
+  if (parsed.title) {
+    summary += `# ${parsed.title}\n\n`;
+    tokens += estimateTokens(summary);
+  }
+
+  // Add first sentence of each section
+  for (const section of parsed.sections) {
+    if (tokens >= maxTokens) break;
+
+    const firstSentence = extractFirstSentence(section.content);
+    summary += `## ${section.heading}\n${firstSentence}\n\n`;
+    tokens += estimateTokens(firstSentence);
+  }
+
+  return summary;
+}
+```
+
+**Pros:**
+- Leverages note structure
+- More meaningful than arbitrary truncation
+- Preserves document hierarchy
+- Still deterministic and fast
+
+**Cons:**
+- Assumes well-structured notes
+- More complex implementation
+- May miss important details in body text
+
+**Cost:** Minimal (just parsing)
+
+**Recommendation:** Good middle ground for structured notes
+
+### Option 4: Token-Budget Allocation
+
+**How it works:**
+- Set total token budget (e.g., 3000 tokens)
+- Allocate proportionally: main note 60%, related notes 40%
+- Use smart truncation within each allocation
+
+```typescript
+interface ContextBudget {
+  totalTokens: number;
+  mainNoteTokens: number;
+  perRelatedNoteTokens: number;
+}
+
+function buildContext(
+  mainNote: Note,
+  relatedNotes: Note[],
+  budget: ContextBudget
+): PromptContext {
+  return {
+    mainNote: {
+      title: mainNote.title,
+      content: truncateToTokens(
+        mainNote.content,
+        budget.mainNoteTokens
+      )
+    },
+    relatedNotes: relatedNotes.map(n => ({
+      title: n.title,
+      content: truncateToTokens(
+        n.content,
+        budget.perRelatedNoteTokens
+      )
+    }))
+  };
+}
+```
+
+**Pros:**
+- Predictable cost control
+- Flexible - can adjust budget by operation
+- Balances coverage vs. depth
+
+**Cons:**
+- Requires token counting
+- Still uses truncation underneath
+
+**Cost:** Low (token estimation overhead)
+
+**Recommendation:** Good for cost control
+
+### Option 5: AI-Powered Summarization
+
+**How it works:**
+- Use AI to summarize each note before including in context
+- Cache summaries to avoid repeated calls
+- Multiple summary lengths for different contexts
+
+```typescript
+async function getSummary(
+  noteId: string,
+  targetLength: 'short' | 'medium' | 'long',
+  cache: SummaryCache
+): Promise<string> {
+  // Check cache first
+  const cached = cache.get(noteId, targetLength);
+  if (cached && !noteHasChangedSince(noteId, cached.timestamp)) {
+    return cached.summary;
+  }
+
+  // Generate new summary
+  const note = await getNote(noteId);
+  const summary = await generateSummary(note.content, {
+    maxLength: targetLength === 'short' ? 100 :
+               targetLength === 'medium' ? 300 : 500,
+    style: 'factual',
+    preserveKeyTerms: true
+  });
+
+  // Cache it
+  cache.set(noteId, targetLength, summary);
+
+  return summary;
+}
+```
+
+**Pros:**
+- Highest quality summaries
+- Intelligently extracts key points
+- Can be tuned for different use cases
+
+**Cons:**
+- Expensive (extra AI calls)
+- Slower (requires summarization step)
+- Summaries might lose important details
+- Complexity of cache invalidation
+
+**Cost:** High (2x AI calls per review minimum)
+
+**Recommendation:** Too expensive for MVP, consider for later
+
+### Option 6: Embedding-Based Retrieval
+
+**How it works:**
+- Pre-compute embeddings for all note paragraphs
+- When generating prompt, retrieve most relevant chunks
+- Only include relevant portions of notes
+
+```typescript
+async function getRelevantContext(
+  mainNoteId: string,
+  relatedNoteIds: string[],
+  embeddingIndex: EmbeddingIndex
+): Promise<ContextChunks> {
+  const mainNote = await getNote(mainNoteId);
+
+  // Get core concept from main note (first paragraph or summary)
+  const mainConcept = extractCoreConcept(mainNote);
+
+  // Find most relevant chunks from related notes
+  const relevantChunks = await embeddingIndex.search({
+    query: mainConcept,
+    filterNoteIds: relatedNoteIds,
+    limit: 5, // top 5 relevant chunks
+    minSimilarity: 0.7
+  });
+
+  return {
+    mainNote: {
+      title: mainNote.title,
+      coreConcept: mainConcept
+    },
+    relatedChunks: relevantChunks
+  };
+}
+```
+
+**Pros:**
+- Only includes relevant portions
+- Scales to very long notes
+- Can handle many related notes
+- Precision over recall
+
+**Cons:**
+- Requires embedding infrastructure
+- Pre-processing overhead
+- May miss context that's relevant but not semantically similar
+- Complex implementation
+
+**Cost:** Medium (embedding generation + storage)
+
+**Recommendation:** Overkill for MVP, but valuable long-term
+
+### Option 7: Hybrid Approach (RECOMMENDED)
+
+**How it works:**
+- Combine multiple strategies based on operation and note size
+- Use simple truncation for short notes
+- Use markdown-aware extraction for longer notes
+- Set hard token budgets as safety net
+
+```typescript
+function buildPromptContext(
+  mainNote: Note,
+  relatedNotes: Note[],
+  operation: 'generate_prompt' | 'analyze_response'
+): PromptContext {
+  // Set token budget based on operation
+  const budget = operation === 'generate_prompt'
+    ? { total: 3000, main: 1800, perRelated: 400 }
+    : { total: 4000, main: 2500, perRelated: 500 };
+
+  // Extract main note context
+  const mainContext = extractNoteContext(mainNote, budget.main);
+
+  // Extract related notes context
+  const relatedContext = relatedNotes
+    .slice(0, 3) // Max 3 related notes
+    .map(note => extractNoteContext(note, budget.perRelated));
+
+  return {
+    mainNote: mainContext,
+    relatedNotes: relatedContext
+  };
+}
+
+function extractNoteContext(note: Note, tokenBudget: number): NoteContext {
+  const content = note.content;
+  const estimatedTokens = estimateTokens(content);
+
+  // If note fits in budget, use it all
+  if (estimatedTokens <= tokenBudget) {
+    return {
+      title: note.title,
+      content: content,
+      truncated: false
+    };
+  }
+
+  // If note is well-structured, use markdown-aware extraction
+  if (hasMarkdownStructure(content)) {
+    return {
+      title: note.title,
+      content: extractMarkdownSummary(content, tokenBudget),
+      truncated: true
+    };
+  }
+
+  // Fallback: smart truncation (start + end)
+  const charBudget = tokenBudget * 4; // rough chars per token
+  return {
+    title: note.title,
+    content: smartTruncate(content, charBudget),
+    truncated: true
+  };
+}
+
+function smartTruncate(content: string, maxChars: number): string {
+  if (content.length <= maxChars) return content;
+
+  // Try to break at paragraph boundary
+  const startPortion = content.slice(0, Math.floor(maxChars * 0.7));
+  const endPortion = content.slice(-Math.floor(maxChars * 0.3));
+
+  // Find last paragraph break in start
+  const lastBreak = startPortion.lastIndexOf('\n\n');
+  const start = lastBreak > maxChars * 0.5
+    ? startPortion.slice(0, lastBreak)
+    : startPortion;
+
+  return start + '\n\n[...]\n\n' + endPortion;
+}
+```
+
+**Pros:**
+- Adapts to note characteristics
+- Balance of simplicity and intelligence
+- Predictable costs
+- Good results for most notes
+
+**Cons:**
+- More complex than single strategy
+- Needs careful testing
+
+**Cost:** Low (computational only)
+
+**Recommendation:** Best for MVP
+
+## Context Budgets by Operation
+
+### Prompt Generation
+
+```
+Total budget: 3,000 tokens
+├─ System prompt: ~500 tokens
+├─ Main note: 1,000-1,500 tokens
+│  ├─ Title + metadata: ~50 tokens
+│  └─ Content summary: 950-1,450 tokens
+├─ Related notes (2-3): 800-1,200 tokens
+│  ├─ Per note: ~300-400 tokens each
+│  └─ Titles + summaries
+└─ Formatting overhead: ~200 tokens
+```
+
+### Response Analysis
+
+```
+Total budget: 5,000 tokens
+├─ System prompt: ~600 tokens
+├─ Original prompt: ~100 tokens
+├─ User response: ~200-500 tokens
+├─ Main note: 2,000-2,500 tokens
+│  ├─ Can be more generous here
+│  └─ Need to verify understanding
+├─ Related notes: 1,000-1,500 tokens
+└─ Formatting: ~200 tokens
+```
+
+## Specific Recommendations for MVP
+
+### Phase 1: Start Simple
+
+**For prompt generation:**
+1. Use markdown-aware extraction (Option 3)
+2. Budget: Main note 500 chars, related notes 300 chars each
+3. Hard limit: 3 related notes maximum
+
+**For response analysis:**
+1. Include full main note content (up to 5000 chars)
+2. Include related note titles + 400 char summaries
+3. User response (full text)
+
+**Implementation:**
+```typescript
+// Prompt generation context
+const promptContext = {
+  mainNote: {
+    title: mainNote.title,
+    summary: extractMarkdownSummary(mainNote.content, 500),
+    tags: mainNote.metadata.tags
+  },
+  relatedNotes: relatedNotes.slice(0, 3).map(n => ({
+    title: n.title,
+    summary: extractMarkdownSummary(n.content, 300),
+    relationship: n.linkType || 'related'
+  }))
+};
+
+// Response analysis context
+const analysisContext = {
+  prompt: generatedPrompt,
+  userResponse: userTypedResponse,
+  mainNote: {
+    title: mainNote.title,
+    content: mainNote.content.slice(0, 5000), // full or first 5k chars
+    tags: mainNote.metadata.tags
+  },
+  relatedNotes: relatedNotes.slice(0, 3).map(n => ({
+    title: n.title,
+    summary: extractMarkdownSummary(n.content, 400)
+  }))
+};
+```
+
+**Estimated costs:**
+- Prompt generation: ~2,000 tokens per call
+- Response analysis: ~4,000 tokens per call
+- Total per review: ~6,000 tokens
+- With Haiku ($0.25/MTok input): ~$0.0015 per review
+- 100 reviews: ~$0.15
+
+### Phase 2: Optimize Based on Data
+
+After MVP, analyze actual performance:
+
+1. **Measure prompt quality** - Are synthesis prompts meaningful?
+2. **Measure analysis quality** - Is AI feedback helpful?
+3. **Check context sufficiency** - Are summaries too short?
+
+Potential improvements:
+- Increase context budgets if quality suffers
+- Add AI summarization for long notes (>5000 chars)
+- Implement caching for frequently accessed notes
+- Use embeddings for very large vaults (1000+ notes)
+
+### Phase 3: Advanced Context Management
+
+For power users with large vaults:
+
+1. **Embedding-based retrieval** - Relevant chunks only
+2. **Smart caching** - Pre-compute summaries
+3. **Adaptive budgets** - More context for complex notes
+4. **User control** - Let users adjust context depth
+
+## Fallback Strategies
+
+### When context is insufficient:
+
+**For prompt generation:**
+- If related notes too long, use title-only synthesis
+- Fallback to single-note prompts if no good related notes
+- Use generic templates if AI generation fails
+
+**For response analysis:**
+- If note too long, prioritize sections mentioned in response
+- Skip detailed feedback if context unclear
+- Provide encouraging but generic feedback
+
+### Error handling:
+
+```typescript
+async function generateSynthesisPrompt(
+  noteId: string
+): Promise<ReviewPrompt> {
+  try {
+    const context = buildPromptContext(noteId);
+
+    // Check if context is sufficient
+    if (!hasEnoughContext(context)) {
+      return generateFallbackPrompt(noteId, 'single-note');
+    }
+
+    const prompt = await callAI(context);
+    return prompt;
+
+  } catch (error) {
+    if (error.code === 'CONTEXT_TOO_LARGE') {
+      // Reduce context and retry
+      return generateSynthesisPrompt(noteId, { reduceContext: true });
+    }
+
+    // Ultimate fallback
+    return getTemplatePrompt(noteId);
+  }
+}
+```
+
+## Future Optimizations
+
+### 1. Summary Caching
+
+Pre-compute and cache summaries:
+```typescript
+interface SummaryCache {
+  noteId: string;
+  lengths: {
+    short: { text: string; timestamp: Date };
+    medium: { text: string; timestamp: Date };
+    long: { text: string; timestamp: Date };
+  };
+  embeddings?: Vector;
+}
+```
+
+Invalidate when note changes:
+- Watch for note edits
+- Regenerate summaries in background
+- Keep old summaries for recent history
+
+### 2. Hierarchical Context
+
+Build context in layers:
+```
+Layer 1: Titles + tags (always include)
+Layer 2: First paragraph summaries (include if budget allows)
+Layer 3: Full markdown structure (include for main note)
+Layer 4: Full content (only for main note in analysis)
+```
+
+### 3. Relevance Scoring
+
+Score each piece of context:
+```typescript
+function scoreRelevance(
+  chunk: string,
+  mainConcept: string,
+  relationship: string
+): number {
+  let score = 0;
+
+  // Explicit links score higher
+  if (relationship === 'explicit-link') score += 50;
+
+  // Shared tags
+  score += countSharedTags(chunk, mainConcept) * 10;
+
+  // Semantic similarity (if embeddings available)
+  score += semanticSimilarity(chunk, mainConcept) * 30;
+
+  return score;
+}
+```
+
+Include only highest-scoring chunks until budget exhausted.
+
+### 4. User Preferences
+
+Let users control trade-offs:
+```yaml
+review:
+  context_strategy: 'balanced' # 'minimal' | 'balanced' | 'comprehensive'
+  max_tokens_per_review: 6000
+  include_full_main_note: true
+  related_notes_count: 3
+  use_ai_summaries: false # enable for large notes
+```
+
+## Comparison Table
+
+| Strategy | Quality | Cost | Speed | Complexity | Scalability |
+|----------|---------|------|-------|------------|-------------|
+| Simple truncation (200 chars) | ⭐⭐ | ⭐⭐⭐⭐⭐ | ⭐⭐⭐⭐⭐ | ⭐ | ⭐⭐⭐⭐⭐ |
+| Smart truncation (start+end) | ⭐⭐⭐ | ⭐⭐⭐⭐⭐ | ⭐⭐⭐⭐⭐ | ⭐ | ⭐⭐⭐⭐⭐ |
+| Markdown-aware | ⭐⭐⭐⭐ | ⭐⭐⭐⭐⭐ | ⭐⭐⭐⭐ | ⭐⭐ | ⭐⭐⭐⭐ |
+| Token budgets | ⭐⭐⭐ | ⭐⭐⭐⭐ | ⭐⭐⭐⭐ | ⭐⭐ | ⭐⭐⭐⭐ |
+| AI summarization | ⭐⭐⭐⭐⭐ | ⭐⭐ | ⭐⭐ | ⭐⭐⭐ | ⭐⭐⭐ |
+| Embedding retrieval | ⭐⭐⭐⭐⭐ | ⭐⭐⭐ | ⭐⭐⭐ | ⭐⭐⭐⭐⭐ | ⭐⭐⭐⭐⭐ |
+| Hybrid (recommended) | ⭐⭐⭐⭐ | ⭐⭐⭐⭐ | ⭐⭐⭐⭐ | ⭐⭐⭐ | ⭐⭐⭐⭐ |
+
+## Implementation Checklist
+
+### MVP (Phase 1)
+
+- [ ] Implement `extractMarkdownSummary()` function
+- [ ] Set context budgets for prompt generation (3k tokens)
+- [ ] Set context budgets for response analysis (5k tokens)
+- [ ] Limit to max 3 related notes
+- [ ] Add fallback for when context insufficient
+- [ ] Add error handling for context too large
+- [ ] Test with various note sizes (100 chars to 10k chars)
+- [ ] Monitor actual token usage in development
+
+### Phase 2 Improvements
+
+- [ ] Add summary caching layer
+- [ ] Implement smart truncation with paragraph awareness
+- [ ] Add token counting utilities
+- [ ] Create adaptive budgets based on note size
+- [ ] Add user preferences for context depth
+- [ ] Measure and log context quality metrics
+
+### Future Enhancements
+
+- [ ] Implement embedding-based retrieval
+- [ ] Add AI-powered summarization for long notes
+- [ ] Build hierarchical context system
+- [ ] Create relevance scoring for chunks
+- [ ] Support user-defined context strategies
+
+## Open Questions
+
+1. **What's the minimum context for good synthesis prompts?**
+   - Need to test with real notes
+   - May vary by domain (technical vs. narrative notes)
+
+2. **Should we include backlinks context?**
+   - Backlinks provide additional connections
+   - But may balloon context size
+   - Consider for Phase 2
+
+3. **How to handle very long notes (10k+ words)?**
+   - Option: Warn user that note may be too long for effective review
+   - Option: Require user to split into smaller notes
+   - Option: Use embedding-based extraction
+
+4. **Should context strategy be per-note-type?**
+   - Literature notes might need more context
+   - Fleeting notes need less
+   - Consider type-aware budgets
+
+5. **Cache invalidation strategy?**
+   - When note edited, invalidate summaries
+   - But what if linked notes change?
+   - Trade-off: accuracy vs. performance
+
+## Conclusion
+
+**For MVP:** Start with hybrid approach (Option 7)
+- Markdown-aware extraction
+- Fixed token budgets
+- Simple and predictable
+- Good enough for most notes
+
+**Monitor and iterate:**
+- Collect metrics on prompt/analysis quality
+- Adjust budgets based on real usage
+- Add more sophisticated strategies as needed
+
+**Long-term:** Move toward embedding-based retrieval for large vaults
+
+The key is to start simple, measure actual performance, and optimize based on data rather than premature optimization.
+
+---
+
+**Document Status:** Analysis complete, ready for review
+**Created:** 2025-01-15
+**Next Steps:** Review with team, implement MVP strategy, test with real notes

--- a/docs/review-mode-prototype.md
+++ b/docs/review-mode-prototype.md
@@ -2,24 +2,25 @@
 
 ## Purpose
 
-This document specifies a **minimal viable prototype** for Flint's AI-powered review mode. The goal is to validate the core concept with the simplest possible implementation that demonstrates the key innovation: **AI-generated prompts that force deep processing**.
+This document specifies a **minimal viable prototype** for Flint's AI-powered review mode. The goal is to validate the core concept with the simplest possible implementation that demonstrates the key innovation: **Agent-driven conversational review that forces deep processing**.
 
 ## Prototype Goals
 
 ### What We're Testing
 
-1. **Does AI-generated synthesis feel valuable?** - Do users find prompts helpful vs. annoying?
+1. **Does agent-driven review feel valuable?** - Can the AI agent create effective review experiences by choosing strategies autonomously?
 2. **Does deep processing work better than passive re-reading?** - Does this approach actually help understanding?
-3. **Is the UX intuitive?** - Can users understand and use the flow without confusion?
+3. **Is the conversational UX intuitive?** - Can users interact naturally with the agent during review?
 4. **Do users want this feature?** - Will they enable review and use it regularly?
+5. **Does full context enable better prompts?** - With complete note content, can the agent generate more meaningful synthesis questions?
 
 ### What We're NOT Testing (Yet)
 
-- Multiple prompt types (just synthesis for MVP)
 - Complex scheduling algorithms (simple fixed intervals)
 - Analytics and metrics (just basic tracking)
 - Workflow integration (manual only)
 - Custom functions (use defaults)
+- Multi-note batch sessions with auto-advance
 
 ## Core Design Decisions
 
@@ -47,28 +48,57 @@ review: true  # Simple boolean to opt-in
 - Tracks: last_reviewed, next_review, review_count, confidence history
 - Frontmatter is source of truth for "enabled", database manages scheduling
 
-### Decision 2: Which Prompt Type? ✅ DECIDED
+### Decision 2: Agent-Driven Review Strategy ✅ DECIDED
 
-**Choice: Synthesis prompts (connect 2-3 notes)**
+**Choice: AI agent autonomously chooses review approach**
 
-**Example:**
+Instead of predetermined prompt types, the agent receives:
+- **Full content** of all notes ready for review
+- **Guidelines** on effective review strategies
+- **Full tool access** to fetch additional context as needed
+
+**The agent decides:**
+- Which review strategy to use (synthesis, application, explanation, reconstruction, etc.)
+- Whether to review notes individually or find thematic connections
+- What additional context to fetch (daily notes, related notes, backlinks)
+- How to adapt based on review history
+
+**Example strategies the agent might choose:**
+
+**Synthesis (connect multiple notes):**
 ```
 Your notes [[elaborative-encoding]] and [[schema-formation]]
 both discuss memory. Explain how elaborative encoding helps
 build schemas. What's the mechanism connecting them?
 ```
 
-**Rationale:**
-- Shows off the knowledge graph advantage
-- Can't be done with traditional flashcards
-- Requires real understanding to answer
-- Demonstrates AI's ability to find connections
-- Works even with small note collections (2+ notes)
+**Application (connect to user's work):**
+```
+Looking at your daily notes, you've been learning React. How could
+you apply retrieval practice to learning React hooks? Give a concrete
+example.
+```
 
-**Alternative considered:** Application prompts
-- **Problem:** Requires extracting user's current projects from daily notes
-- **Complexity:** Parser for daily notes, project detection logic
-- **Decision:** Save for Phase 2, use synthesis for MVP
+**Reconstruction (memory test):**
+```
+Without looking at the note, explain the main argument in your own
+words. Then we'll compare.
+```
+
+**Thematic review (multiple notes with shared theme):**
+```
+I noticed these three notes due today all relate to learning theory.
+Rather than review them separately, let's synthesize: how do they
+work together as a system?
+```
+
+**Rationale:**
+- **More flexible** - Agent adapts to note characteristics and user context
+- **More intelligent** - Can discover connections and patterns
+- **More natural** - Conversational flow rather than rigid templates
+- **Simpler implementation** - No need to pre-categorize prompt types
+- **Better use of AI** - Leverages agent's reasoning capabilities
+- **Full context available** - With complete notes, agent can make better decisions
 
 ### Decision 3: Review Trigger - How to Start Review? ✅ DECIDED
 
@@ -91,62 +121,126 @@ Main Navigation:
 
 ### Decision 4: Review UI - Where Does Review Happen? ✅ DECIDED
 
-**Choice: Dedicated Full-Screen Review View**
+**Choice: Conversational Review Interface (AI Assistant View)**
+
+Review happens through natural conversation with the AI agent, similar to the AI Assistant view but in review context.
 
 ```
 ┌─────────────────────────────────────────────────┐
-│ Review: [[elaborative-encoding]]          [X]   │
+│ Review Session                            [X]   │
 ├─────────────────────────────────────────────────┤
 │                                                 │
-│ 🤔 Synthesis Prompt:                            │
+│ AI: I see you have 3 notes ready for review:    │
+│     • [[elaborative-encoding]]                  │
+│     • [[schema-formation]]                      │
+│     • [[retrieval-practice]]                    │
 │                                                 │
-│ Your notes [[elaborative-encoding]] and         │
-│ [[schema-formation]] both discuss memory...     │
+│     These all relate to learning - let me       │
+│     create a synthesis review for you.          │
 │                                                 │
-│ ──────────────────────────────────────────────│
+│ ───────────────────────────────────────────────│
 │                                                 │
-│ Your Response:                                  │
+│ AI: Your notes [[elaborative-encoding]] and     │
+│     [[schema-formation]] both discuss memory    │
+│     organization. Explain how elaborative       │
+│     encoding helps build schemas.               │
+│                                                 │
+│ ───────────────────────────────────────────────│
+│                                                 │
+│ You: [Type your explanation here...]            │
+│                                                 │
 │ ┌───────────────────────────────────────────┐ │
-│ │ [User types explanation here]             │ │
-│ │                                           │ │
 │ │                                           │ │
 │ └───────────────────────────────────────────┘ │
 │                                                 │
-│ [Show Note Content] [Submit]                    │
+│ [Show Note Content] [Send]                      │
+└─────────────────────────────────────────────────┘
+```
+
+After user responds:
+```
+┌─────────────────────────────────────────────────┐
+│ You: Elaborative encoding creates connections   │
+│      between new info and existing knowledge... │
+│                                                 │
+│ ───────────────────────────────────────────────│
+│                                                 │
+│ AI: Excellent! You captured the core mechanism. │
+│     Elaborative encoding creates the links, and │
+│     those links become schema structure.        │
+│                                                 │
+│     I also notice you have [[memory-            │
+│     consolidation]] which relates closely.      │
+│     Should we add a link?                       │
+│                                                 │
+│     Did you understand this concept well?       │
+│     [Pass] [Fail]                               │
 └─────────────────────────────────────────────────┘
 ```
 
 **Rationale:**
-- Dedicated system view (like Inbox, Daily)
-- Focus mode for review
-- Full screen real estate for typing
-- Clear workflow separation from editing
-- Can show note content below when revealed
+- **Natural conversation** - More engaging than rigid forms
+- **Agent-driven flow** - AI guides the review experience
+- **Flexible interaction** - User can ask questions, request hints
+- **Reuses existing UI** - Similar to AI Assistant view
+- **Simpler implementation** - No complex multi-step modal state
+- **More powerful** - Agent can fetch additional notes, adapt strategy mid-review
 
-### Decision 5: Prompt Generation - When? ✅ DECIDED
+### Decision 5: Context and Agent Initialization ✅ DECIDED
 
-**Choice: Generate During Review (On-Demand)**
+**Choice: Provide full context upfront, agent generates strategy dynamically**
+
+When user starts review session:
 
 ```
-User clicks "Review Now"
-  → Load note
-  → Show loading state
-  → Call AI to generate prompt
-  → Display prompt and response area
+User clicks "Start Review"
+  → Fetch all notes due for review (with FULL content)
+  → Fetch recent daily notes (for project context)
+  → Initialize agent with:
+     • All due notes (complete content, metadata, stats)
+     • Review guidelines (synthesis, application, etc.)
+     • Available tools (get_note, get_linked_notes, search_daily_notes)
+  → Agent analyzes and proposes review approach
+  → Conversational review begins
+```
+
+**Initial Context Structure:**
+```typescript
+{
+  notesForReview: [
+    {
+      id: "note-123",
+      title: "Elaborative Encoding",
+      content: "...", // FULL CONTENT - no truncation
+      metadata: {
+        tags: ["learning", "memory"],
+        created: "2024-01-10",
+        lastReviewed: "2024-01-08",
+        reviewCount: 2,
+        lastConfidence: "pass"
+      },
+      stats: {
+        outboundLinks: 5,
+        backlinks: 12,
+        relatedByTags: 8
+      }
+    }
+    // ... more notes
+  ],
+  recentContext: {
+    dailyNotes: [...], // Last 7 days for project awareness
+  },
+  reviewGuidelines: "..." // Strategies the agent can use
+}
 ```
 
 **Rationale:**
-- Always fresh, uses latest knowledge graph
-- Simpler implementation (no background jobs)
-- Prompts reflect user's current context
-- 2-3 second wait is acceptable with good loading UX
-
-**Loading State:**
-```
-Analyzing your knowledge graph...
-Generating synthesis prompt...
-[Spinner]
-```
+- **Full context** - Agent sees complete notes, makes better decisions
+- **On-demand tool calls** - Agent fetches additional context only if needed
+- **Adaptive** - Agent can change strategy mid-review if needed
+- **Simpler than pre-generation** - No need to anticipate what agent needs
+- **Cost-effective** - Only pay for context actually used
+- **Fresh every time** - Always uses current state of knowledge graph
 
 ### Decision 6: Response Capture - How Does User Answer? ✅ DECIDED
 
@@ -351,116 +445,140 @@ understanding through spaced repetition.
 [Learn More]
 ```
 
-#### 3. Review Modal
+#### 3. Review Session Interface
 
-**Triggered by:** Clicking [Review Now] button
+**Triggered by:** Clicking "Start Review" from Review view
 
-**Flow:**
+**Conversational Flow:**
 
-**Step 1: Loading**
+The review session opens in a chat-like interface where the agent guides the user through reviewing notes.
+
+**Step 1: Session Initialization**
 ```
 ┌─────────────────────────────────────────────┐
-│ Review: [[elaborative-encoding]]            │
+│ Review Session                        [X]   │
 ├─────────────────────────────────────────────┤
 │                                             │
-│ Analyzing your knowledge graph...           │
+│ AI: Starting review session...              │
+│     Loading your notes...                   │
 │                                             │
 │ [Loading spinner]                           │
-│                                             │
 └─────────────────────────────────────────────┘
 ```
 
-**Step 2: Prompt Shown + Response Entry**
+**Step 2: Agent Analyzes and Proposes Strategy**
 ```
 ┌─────────────────────────────────────────────┐
-│ Review: [[elaborative-encoding]]            │
-│ Last reviewed: 7 days ago · Review #2       │
+│ Review Session                        [X]   │
 ├─────────────────────────────────────────────┤
 │                                             │
-│ 🤔 Synthesis Prompt:                        │
+│ AI: I see you have 3 notes ready for        │
+│     review today:                           │
 │                                             │
-│ Your notes [[elaborative-encoding]] and     │
-│ [[schema-formation]] both discuss how       │
-│ memory is organized. Explain how            │
-│ elaborative encoding helps build schemas.   │
-│ What's the mechanism connecting them?       │
+│     • [[elaborative-encoding]]              │
+│       Last reviewed: 7 days ago             │
 │                                             │
-│ Related: [[schema-formation]], [[memory]]   │
+│     • [[schema-formation]]                  │
+│       Last reviewed: 14 days ago            │
+│                                             │
+│     • [[retrieval-practice]]                │
+│       Last reviewed: 3 days ago             │
+│                                             │
+│     These all relate to learning theory.    │
+│     I'd like to do a synthesis review       │
+│     connecting all three. Sound good?       │
 │                                             │
 │ ───────────────────────────────────────────│
 │                                             │
-│ Your Response:                              │
-│ ┌─────────────────────────────────────────┐ │
-│ │ [Type your explanation here...]         │ │
-│ │                                         │ │
-│ │                                         │ │
-│ │                                         │ │
-│ └─────────────────────────────────────────┘ │
-│                                             │
-│ [Show Note Content] [Submit Response]       │
+│ You: [Type response or "yes"]               │
 │                                             │
 └─────────────────────────────────────────────┘
 ```
 
-**Step 3: AI Analysis + Note Content**
+**Step 3: Agent Poses Review Challenge**
 ```
 ┌─────────────────────────────────────────────┐
-│ Review: [[elaborative-encoding]]            │
-├─────────────────────────────────────────────┤
+│ AI: Perfect. Here's your challenge:         │
 │                                             │
-│ Your Response:                              │
-│ "Elaborative encoding creates connections   │
-│ between new info and existing knowledge.    │
-│ These connections form schemas..."          │
+│     Your notes [[elaborative-encoding]],    │
+│     [[schema-formation]], and [[retrieval-  │
+│     practice]] form a learning system.      │
 │                                             │
-│ ───────────────────────────────────────────│
+│     Explain how these three concepts work   │
+│     together:                               │
+│     1. What's the sequence?                 │
+│     2. How do they reinforce each other?    │
+│     3. How would you apply all three to     │
+│        learning React? (I noticed you're    │
+│        working on that from your daily      │
+│        notes)                               │
 │                                             │
-│ 💡 AI Analysis:                             │
-│                                             │
-│ Great! You captured the core mechanism.     │
-│ Elaborative encoding creates the links,     │
-│ and those links become schema structure.    │
-│                                             │
-│ Consider: This also connects to             │
-│ [[memory-consolidation]] - the connections  │
-│ you create during encoding strengthen       │
-│ during consolidation.                       │
-│                                             │
-│ [Create link to [[memory-consolidation]]?]  │
+│     Take your time - this is a synthesis    │
+│     question.                               │
 │                                             │
 │ ───────────────────────────────────────────│
 │                                             │
-│ 📄 Note Content: [Click to show/hide]      │
+│ You: [Large text area for typed response]   │
 │                                             │
-│ ───────────────────────────────────────────│
-│                                             │
-│ Did you understand this concept well?       │
-│                                             │
-│ [Pass] [Fail]                               │
-│                                             │
+│ [Show Note Contents] [Send]                 │
 └─────────────────────────────────────────────┘
 ```
 
-**Step 4: Complete**
+**Step 4: Agent Analyzes Response**
 ```
-✓ Review complete!
-
-Next review: January 22 (in 7 days)
-
-[Close] [Review Another Note]
+┌─────────────────────────────────────────────┐
+│ You: [User's typed explanation...]          │
+│                                             │
+│ ───────────────────────────────────────────│
+│                                             │
+│ AI: Excellent synthesis! You captured the   │
+│     key relationships between encoding,     │
+│     schema formation, and retrieval.        │
+│                                             │
+│     I particularly liked your React         │
+│     example - building schemas through      │
+│     practice, then testing retrieval.       │
+│                                             │
+│     One connection you might add: This      │
+│     relates to [[memory-consolidation]]     │
+│     which explains why spacing these        │
+│     practices over days works better.       │
+│                                             │
+│     Would you like me to add a link to      │
+│     [[memory-consolidation]]?               │
+│     [Yes] [No]                              │
+│                                             │
+│     Did you understand these concepts well? │
+│     [Pass] [Fail]                           │
+└─────────────────────────────────────────────┘
 ```
 
-*If user clicks [Fail]:*
+**Step 5: Completion and Next Steps**
 ```
-✓ Review saved
-
-We'll review this again tomorrow so you can
-reinforce your understanding.
-
-Next review: Tomorrow
-
-[Close] [Review Another Note]
+┌─────────────────────────────────────────────┐
+│ AI: ✓ Review complete!                      │
+│                                             │
+│     I've updated your review schedule:      │
+│     • [[elaborative-encoding]] → Jan 22     │
+│     • [[schema-formation]] → Jan 22         │
+│     • [[retrieval-practice]] → Jan 22       │
+│                                             │
+│     Great synthesis today. Next review      │
+│     in 7 days.                              │
+│                                             │
+│     [Close] [Start Another Review]          │
+└─────────────────────────────────────────────┘
 ```
+
+**Flexible Interaction:**
+
+User can also:
+- Ask for hints: "Can you give me a hint?"
+- Request different approach: "Too hard, can we review these separately?"
+- Show note content anytime: "Show me the elaborative encoding note"
+- Skip a note: "Let's skip this one for now"
+
+Agent adapts accordingly.
 
 #### 4. Database Schema (Minimal)
 
@@ -493,89 +611,147 @@ CREATE INDEX idx_review_next_review ON review_items(next_review, enabled);
 - User responses stored for future reference
 - No complex review_sessions table in MVP
 
-#### 5. Prompt Generation System
+#### 5. Agent Tools for Review
 
-**MCP Tool:**
+**MCP Tools available to the review agent:**
 
 ```typescript
+// Core context access
 {
-  name: "generate_synthesis_prompt",
-  description: "Generate synthesis prompt connecting 2-3 related notes",
+  name: "get_note",
+  description: "Fetch complete note by ID",
   inputSchema: {
-    note_id: string,
-    max_related_notes: number // default: 2
+    note_id: string
   },
   outputSchema: {
-    prompt: string,
-    related_notes: string[], // Note IDs referenced in prompt
-    fallback: boolean // True if couldn't find related notes
+    id: string,
+    title: string,
+    content: string,  // Full content
+    metadata: object,
+    stats: object
+  }
+}
+
+{
+  name: "get_linked_notes",
+  description: "Get notes that this note links to",
+  inputSchema: {
+    note_id: string,
+    include_content: boolean  // default: false (just titles)
+  },
+  outputSchema: {
+    outbound: Array<Note>,
+    inbound: Array<Note>
+  }
+}
+
+{
+  name: "search_notes_by_tags",
+  description: "Find notes with shared tags",
+  inputSchema: {
+    tags: string[],
+    limit: number
+  },
+  outputSchema: {
+    notes: Array<Note>
+  }
+}
+
+{
+  name: "search_daily_notes",
+  description: "Search recent daily notes for context (e.g., current projects)",
+  inputSchema: {
+    days_back: number,  // default: 7
+    query?: string      // optional search term
+  },
+  outputSchema: {
+    dailyNotes: Array<{
+      date: string,
+      content: string,
+      projects_mentioned: string[]
+    }>
+  }
+}
+
+{
+  name: "complete_review",
+  description: "Mark note as reviewed with pass/fail",
+  inputSchema: {
+    note_id: string,
+    passed: boolean,
+    user_response: string,
+    connections_created?: string[]  // optional new links
+  },
+  outputSchema: {
+    next_review_date: string,
+    review_count: number
+  }
+}
+
+{
+  name: "create_note_link",
+  description: "Add a link between two notes",
+  inputSchema: {
+    from_note_id: string,
+    to_note_id: string,
+    context?: string  // optional context for why link was created
   }
 }
 ```
 
-**Algorithm:**
+**Agent System Prompt (Review Guidelines):**
+
+```
+You are helping a user review their notes to build deep understanding
+through spaced repetition. Your role is to create review experiences
+that force deep cognitive processing, not shallow recognition.
+
+Available review strategies:
+
+1. SYNTHESIS - Connect 2-3 related notes, ask user to explain relationships
+2. APPLICATION - Connect concepts to user's current projects/work
+3. RECONSTRUCTION - Ask user to explain from memory before revealing content
+4. EXPLANATION - Ask user to teach the concept to an imagined audience
+5. CRITICAL ANALYSIS - Ask what user would add/change with current knowledge
+6. CONNECTION DISCOVERY - Suggest implicit links for user to evaluate
+
+Choose the strategy based on:
+- Note characteristics (well-connected vs isolated)
+- Review history (first time vs. confident)
+- User's current work (check daily notes for active projects)
+- Relationships between notes due today
+
+Guidelines:
+- Use FULL note content to generate specific, contextual questions
+- Reference specific notes with [[wikilink]] syntax
+- Ask "how" and "why", not "what"
+- Adapt difficulty based on review history
+- Suggest connections to strengthen knowledge graph
+- Be encouraging and constructive in feedback
+
+You have tools to fetch additional notes, search daily notes, and
+create links. Use them to create the best review experience.
+```
+
+**Example Agent Flow:**
 
 ```typescript
-async function generateSynthesisPrompt(noteId: string) {
-  // 1. Get note content and metadata
-  const note = await getNote(noteId);
+// Agent receives initial context with all due notes
+const context = {
+  notesForReview: [
+    { id: "1", title: "Elaborative Encoding", content: "...", /* full */ },
+    { id: "2", title: "Schema Formation", content: "...", /* full */ },
+    { id: "3", title: "Retrieval Practice", content: "...", /* full */ }
+  ],
+  recentDailyNotes: [...],
+  reviewGuidelines: "..."
+};
 
-  // 2. Find related notes (prefer explicit links first)
-  let relatedNotes = await getLinkedNotes(noteId);
-
-  // 3. If fewer than 2 links, find by tags or similarity
-  if (relatedNotes.length < 2) {
-    const byTags = await getNotesWithSharedTags(noteId, limit: 5);
-    relatedNotes = [...relatedNotes, ...byTags].slice(0, 3);
-  }
-
-  // 4. If still < 2, use fallback prompt (single-note review)
-  if (relatedNotes.length < 1) {
-    return {
-      prompt: `Explain the main concept in this note in your own words. What are the key ideas and how do they connect?`,
-      related_notes: [],
-      fallback: true
-    };
-  }
-
-  // 5. Generate synthesis prompt with AI
-  const prompt = await generateWithAI({
-    systemPrompt: `You are helping create review prompts for a note-taking app.
-
-    Generate a synthesis prompt that:
-    - Requires explaining how 2-3 concepts connect
-    - Cannot be answered with simple recall
-    - References specific notes by title using [[wikilink]] syntax
-    - Is specific to the user's actual notes, not generic
-    - Asks "how" or "why", not "what"
-
-    Keep it concise (2-3 sentences max).`,
-
-    context: {
-      mainNote: {
-        title: note.title,
-        summary: extractSummary(note.content, maxLength: 200)
-      },
-      relatedNotes: relatedNotes.map(n => ({
-        title: n.title,
-        summary: extractSummary(n.content, maxLength: 200),
-        relationship: n.linkType || 'related'
-      }))
-    }
-  });
-
-  return {
-    prompt: prompt,
-    related_notes: relatedNotes.map(n => n.id),
-    fallback: false
-  };
-}
+// Agent analyzes and chooses strategy
+// Might call search_daily_notes() to check user's current projects
+// Might call get_linked_notes() to see connections
+// Then creates conversational review experience
 ```
-
-**Fallback Strategy:**
-- If no related notes: Single-note explanation prompt
-- If AI generation fails: Template-based prompt
-- If note has no content: Skip review
 
 #### 6. Pass/Fail Scheduler
 
@@ -616,16 +792,16 @@ function completeReview(noteId: string, passed: boolean, userResponse: string) {
 
 ### What's Explicitly NOT in MVP
 
-1. **Multiple prompt types** - Only synthesis, no application/explanation/reconstruction/etc.
-2. **Session mode** - No auto-advance through multiple notes
-3. **Analytics dashboard** - No charts, statistics, or retention metrics
-4. **Workflow integration** - No automated triggers or workflow-based review
-5. **Custom prompts** - No user editing of prompt templates
-6. **Adaptive scheduling** - Fixed pass/fail intervals, no SM-2 yet
-7. **Progressive hints** - No hint system if user is stuck (just "show note")
-8. **Review from chat** - No conversational interface, UI-only
-9. **Prompt regeneration** - Can't ask for different prompt (single attempt)
-10. **Multiple difficulty levels** - All prompts same difficulty (no easy/hard modes)
+1. **SM-2 adaptive scheduling** - Fixed pass/fail intervals (1 day / 7 days) for simplicity
+2. **Analytics dashboard** - No charts, statistics, or retention metrics
+3. **Workflow integration** - No automated triggers or workflow-based review
+4. **Custom prompt templates** - Agent generates all prompts, no user-defined templates
+5. **Multi-session tracking** - No session analytics or streak tracking
+6. **Batch auto-advance** - User manually starts each review, no auto-advance through queue
+7. **Review reminders** - No notifications or daily review reminders
+8. **Export/import** - No data export or integration with other SRS tools
+9. **Mobile optimization** - Desktop-first, mobile is future work
+10. **Embedding-based similarity** - Uses links and tags only, no semantic search yet
 
 ## Implementation Checklist
 
@@ -634,18 +810,10 @@ function completeReview(noteId: string, passed: boolean, userResponse: string) {
 - [ ] Database migration: Create `review_items` table
 - [ ] API: `enableReview(noteId)` → Sets `review: true` in frontmatter
 - [ ] API: `disableReview(noteId)` → Sets `review: false` in frontmatter
-- [ ] API: `getNotesForReview()` → Returns notes where `next_review <= today`
+- [ ] API: `getNotesForReview()` → Returns notes where `next_review <= today` with FULL content
 - [ ] API: `completeReview(noteId, passed, userResponse)` → Updates schedule
-- [ ] Prompt generation: `generateSynthesisPrompt(noteId)`
-  - Get linked notes
-  - Fallback to tag-based similarity
-  - Call AI to generate prompt
-  - Handle errors gracefully
-- [ ] Response analysis: `analyzeReviewResponse(noteId, prompt, userResponse)`
-  - AI analyzes user's explanation
-  - Identifies what was captured well
-  - Suggests additional connections
-  - Returns constructive feedback
+- [ ] API: `getRecentDailyNotes(daysBack)` → Returns recent daily notes for context
+- [ ] API: `createNoteLink(fromId, toId)` → Adds link between notes
 
 ### Frontend (Renderer)
 
@@ -660,96 +828,180 @@ function completeReview(noteId: string, passed: boolean, userResponse: string) {
   - List notes due for review
   - Show "upcoming" section
   - Empty state message
-  - Full-screen review interface (not modal)
-- [ ] Review flow UI
-  - Step 1: Loading state with spinner
-  - Step 2: Show prompt + response text area
-  - Step 3: AI analysis + note content (collapsible)
-  - Step 4: Pass/Fail buttons
-  - Step 5: Completion message with next review date
-- [ ] Store: Review state management
-  - Track current review state
-  - Cache prompts
-  - Store user responses
+  - "Start Review" button
+- [ ] Review session interface
+  - Conversational UI (chat-like)
+  - Message history
+  - Text input for user responses
+  - Pass/Fail buttons (inline with agent messages)
+  - "Show Note Content" action button
+- [ ] Store: Review session state management
+  - Track conversation history
+  - Store agent context (notes being reviewed)
   - Handle pass/fail submission
+  - Track which notes completed in session
 
 ### AI Integration
 
-- [ ] MCP tool: `generate_synthesis_prompt`
-  - System prompt for creating synthesis questions
-  - Context: note content + related notes
-  - Returns: prompt text + related note IDs
-- [ ] MCP tool: `analyze_review_response`
-  - System prompt for analyzing user responses
-  - Context: prompt + user response + note content
-  - Returns: feedback text + suggested connections
-- [ ] Error handling for AI failures
-  - Fallback prompts (templates) if generation fails
-  - Graceful degradation if analysis fails
-  - Timeout handling (10s max)
+- [ ] Review agent system prompt
+  - Guidelines for review strategies (synthesis, application, etc.)
+  - Instructions for adapting to note characteristics
+  - Emphasis on deep processing over recognition
+- [ ] MCP tools: `get_note`, `get_linked_notes`, `search_notes_by_tags`
+  - Allow agent to fetch additional context as needed
+- [ ] MCP tool: `search_daily_notes`
+  - Extract user's current projects/work
+  - Provide context for application prompts
+- [ ] MCP tool: `complete_review`
+  - Mark note as reviewed
+  - Update next review date
+  - Store user response in history
+- [ ] MCP tool: `create_note_link`
+  - Allow agent to suggest and create links
+  - Build knowledge graph during review
+- [ ] Agent initialization
+  - Load all due notes with full content
+  - Include recent daily notes for context
+  - Start conversational review flow
+- [ ] Error handling
+  - Graceful degradation if agent fails
+  - Timeout handling
+  - Fallback to simple "explain this note" if agent can't generate strategy
 
 ### Polish
 
-- [ ] Loading states (spinners for prompt generation and analysis)
-- [ ] Error messages (AI timeout, no related notes, generation failed)
-- [ ] Toast notifications (review enabled, completed, link created)
+- [ ] Loading states
+  - Spinner when initializing review session
+  - Typing indicator while agent is thinking
+  - Loading state when fetching notes
+- [ ] Error messages
+  - AI timeout (with retry option)
+  - No notes due today (friendly message)
+  - Agent initialization failed (fallback to simple review)
+- [ ] Toast notifications
+  - Review enabled
+  - Review completed with next date
+  - Link created between notes
 - [ ] Keyboard shortcuts
-  - `Cmd/Ctrl+Enter` to submit response
-  - `P` for Pass, `F` for Fail
-- [ ] Responsive design (full-screen view on all sizes)
-- [ ] Empty state when no notes are due
-- [ ] Smooth transitions between review steps
+  - `Cmd/Ctrl+Enter` to send message
+  - `Escape` to close review session
+- [ ] Conversational UI polish
+  - Markdown rendering in agent messages
+  - [[wikilink]] highlighting and clicking
+  - Smooth scroll to new messages
+  - Auto-focus on text input
+- [ ] Empty states
+  - No notes due for review
+  - No notes enabled for review yet
+- [ ] Responsive design (desktop-first for MVP)
 
 ## Success Metrics for Prototype
 
 ### Usage Metrics
 - % of users who enable review for at least 1 note
 - % of due reviews that get completed (completion rate)
-- Average time spent per review
+- Average time spent per review session
 - Pass rate (% reviews marked as passed)
 - Average response length (words)
+- Notes reviewed per session (are users reviewing multiple?)
+- Link creation rate (connections made during review)
 
 ### Qualitative Feedback
-- Do users find AI-generated prompts valuable vs. annoying?
+- Do users find agent-driven review valuable vs. rigid prompts?
+- Is the conversational interface intuitive?
 - Is the typing requirement acceptable or too much friction?
-- Is AI feedback helpful or unnecessary?
-- Are prompts appropriate difficulty?
+- Are agent's review strategies appropriate (synthesis, application, etc.)?
+- Does full note context lead to better prompts?
 - Would users use this regularly?
 - Do pass/fail feel sufficient or do users want more granularity?
+- Is agent feedback helpful and encouraging?
 
 ### Technical Validation
-- Does prompt generation work reliably (>95% success rate)?
-- Does AI analysis provide useful feedback?
+- Does agent successfully generate review strategies (>95% success rate)?
+- Are agent's chosen strategies appropriate for the notes?
+- Does agent effectively use tools (fetch related notes, search daily notes)?
+- Is agent feedback constructive and accurate?
 - Are pass/fail intervals reasonable (7 days / 1 day)?
-- Do users find enough related notes for synthesis?
 - Database schema sufficient for tracking?
-- Performance acceptable (2-3s for prompt, 3-4s for analysis)?
+- Performance acceptable with full note content?
+- Cost per review session within budget (target: <$0.10/session)?
 
 ## Migration Path to Full Feature
 
-### Phase 1: Core Review System
-- Add SM-2 adaptive scheduling
-- Replace fixed intervals with confidence-based
-- Add review history tracking
-- Improve prompt generation (more context)
+### Phase 1: Enhanced Agent Capabilities
+- Add SM-2 adaptive scheduling (replace fixed intervals)
+- Embedding-based note similarity (beyond links and tags)
+- More sophisticated daily note parsing (project extraction)
+- Review history analysis (agent adapts based on past performance)
+- Multi-turn conversations (user can ask followup questions)
 
 ### Phase 2: Enhanced UX
-- Add review session mode (auto-advance)
-- Add review dashboard with basic stats
-- Add keyboard shortcuts
-- Add progressive hints
+- Auto-advance through multiple notes in session
+- Review dashboard with basic stats
+- Review history browser
+- Progressive hints system
+- Mobile-optimized review interface
 
-### Phase 3: AI Integration
-- Add multiple prompt types (application, explanation)
-- Add AI response analysis (for typed responses)
-- Add connection suggestions during review
-- Conversational review via AI chat
+### Phase 3: Advanced Features
+- Custom review strategies (user-defined prompt templates)
+- Workflow integration (scheduled review sessions)
+- Review analytics and insights
+- Bulk operations (enable review for many notes)
+- Export review data
 
-### Phase 4: Power Features
-- Custom prompt templates
-- Workflow integration
-- Custom functions for scheduling
-- Bulk operations
+### Phase 4: Intelligence & Optimization
+- Agent learns from review patterns
+- Personalized difficulty adaptation
+- Optimal review timing predictions
+- Knowledge graph analysis during review
+- Retention prediction and recommendations
+
+## Cost and Context Estimates
+
+### Context Budget per Review Session
+
+**Initial context (passed to agent):**
+- Notes for review: 3 notes × ~2,000 tokens each = 6,000 tokens
+- Recent daily notes: 7 days × ~300 tokens = 2,100 tokens
+- Review guidelines: ~1,000 tokens
+- Metadata and stats: ~500 tokens
+- **Total input: ~9,600 tokens**
+
+**Agent output:**
+- Review conversation: ~1,000-1,500 tokens
+- Analysis and feedback: ~500 tokens
+- **Total output: ~1,500 tokens**
+
+**Tool calls (if agent uses them):**
+- `get_linked_notes`: ~500 tokens (titles + summaries)
+- `search_daily_notes`: ~1,000 tokens (if searching)
+- Additional notes fetched: ~2,000 tokens each
+
+**Total per session estimate: 10,000-15,000 tokens**
+
+### Cost Estimates
+
+**With Sonnet ($3/MTok input, $15/MTok output):**
+- Input: 12,000 tokens × $3/MTok = $0.036
+- Output: 1,500 tokens × $15/MTok = $0.0225
+- Tool calls: ~3,000 tokens × $3/MTok = $0.009
+- **Total per session: ~$0.07**
+- **Per note: ~$0.02-0.03**
+
+**With Haiku ($0.25/MTok input, $1.25/MTok output):**
+- Input: 12,000 tokens × $0.25/MTok = $0.003
+- Output: 1,500 tokens × $1.25/MTok = $0.0019
+- Tool calls: ~3,000 tokens × $0.25/MTok = $0.0008
+- **Total per session: ~$0.006**
+- **Per note: ~$0.002**
+
+**Recommendation:** Start with Sonnet for better agent reasoning, evaluate if Haiku is sufficient.
+
+**Monthly cost (100 review sessions):**
+- Sonnet: ~$7/month
+- Haiku: ~$0.60/month
+
+Very affordable compared to value provided!
 
 ## Open Questions for User Feedback
 
@@ -757,72 +1009,133 @@ function completeReview(noteId: string, passed: boolean, userResponse: string) {
    - Currently: Manual opt-in
    - Alternative: Auto-enable with ability to disable
 
-2. **Is mental-only answer sufficient or do users want to type?**
-   - Currently: Mental only (think then rate)
-   - Alternative: Optional text box
+2. **Is agent autonomy acceptable or do users want control?**
+   - Currently: Agent chooses review strategy
+   - Alternative: User picks from menu (synthesis, application, etc.)
 
-3. **Are synthesis prompts the right starting point?**
-   - Currently: Only synthesis (connect 2-3 notes)
-   - Alternative: Start with simpler reconstruction prompts?
+3. **Is conversational UI better than structured forms?**
+   - Currently: Chat-like interface
+   - Alternative: Rigid prompt → response → feedback flow
 
-4. **Is fixed scheduling acceptable or do users expect adaptation?**
-   - Currently: Fixed intervals (1, 3, 7, 14 days)
-   - Alternative: Add SM-2 in MVP even though more complex?
+4. **Should agent suggest thematic reviews (multiple notes at once)?**
+   - Currently: Agent can choose to review notes together or separately
+   - Alternative: Always review notes individually
 
-5. **Should review view be prominent or hidden?**
-   - Currently: Main navigation item
-   - Alternative: Subtle badge on All Notes view?
+5. **Is typing required or should it be optional?**
+   - Currently: Required text response
+   - Alternative: Optional typing, or mental-only with pass/fail
 
 ## Risk Mitigation
 
-### Risk: Prompts are low quality
-- **Mitigation:** Test with real user notes before launch
-- **Fallback:** Template-based prompts if AI fails
+### Risk: Agent-generated strategies are poor quality
+- **Mitigation:** Test agent with real user notes before launch
+- **Mitigation:** Include diverse strategy examples in system prompt
+- **Fallback:** Simple template-based prompts if agent fails
 - **Escape hatch:** Users can disable review per note
 
 ### Risk: Users don't understand the value
-- **Mitigation:** Clear onboarding explanation
-- **Mitigation:** "Learn More" link with examples
+- **Mitigation:** Clear onboarding explanation with example
+- **Mitigation:** "Learn More" link demonstrating agent capabilities
 - **Escape hatch:** Feature is opt-in, non-intrusive
 
-### Risk: Review feels like a chore
-- **Mitigation:** Keep it fast (mental-only answers)
-- **Mitigation:** No guilt (just shows what's due)
-- **Mitigation:** No streaks or pressure
+### Risk: Conversational interface confusing
+- **Mitigation:** Keep agent instructions clear and explicit
+- **Mitigation:** Use familiar chat UI patterns
+- **Testing:** Extensive user testing with MVP
+- **Fallback:** Can revert to rigid flow if needed
 
-### Risk: AI costs too high
-- **Mitigation:** Only generate prompts on-demand
-- **Mitigation:** Cache prompts (reuse if note unchanged)
-- **Mitigation:** Use cheap model (Haiku) for prompt generation
+### Risk: AI costs too high with full note content
+- **Mitigation:** Cost estimates show ~$0.07/session (affordable)
+- **Mitigation:** Can switch to Haiku (~$0.006/session) if needed
+- **Monitoring:** Track actual costs in production
+- **Cap:** Set per-user monthly limits if necessary
 
 ### Risk: Not enough related notes for synthesis
-- **Mitigation:** Graceful fallback to single-note prompts
-- **Mitigation:** Only suggest review for well-connected notes
-- **Mitigation:** Clear messaging when feature won't work well
+- **Mitigation:** Agent can choose single-note reconstruction instead
+- **Mitigation:** Agent adapts strategy to available context
+- **Mitigation:** Only suggest review for notes with some connections
+
+### Risk: Agent takes too long to respond
+- **Mitigation:** Set strict timeouts (15s max)
+- **Fallback:** Simple template prompt if agent times out
+- **UX:** Show typing indicator so user knows agent is working
+
+## Advantages of Agent-Driven Approach
+
+### Compared to Predetermined Prompts
+
+**Agent-Driven (Chosen Approach):**
+- ✅ **Adaptive** - Chooses best strategy for each note/context
+- ✅ **Intelligent** - Discovers connections and themes
+- ✅ **Contextual** - Incorporates user's current work/projects
+- ✅ **Conversational** - Natural, flexible interaction
+- ✅ **Simpler implementation** - No need to pre-categorize strategies
+- ✅ **Full context** - Agent sees complete notes, makes better decisions
+- ✅ **Tool access** - Can fetch additional context as needed
+- ✅ **Future-proof** - Easy to add new strategies without UI changes
+
+**Predetermined Prompts (Original Spec):**
+- ❌ Fixed strategy per note type
+- ❌ Limited context (200-char summaries)
+- ❌ Rigid UI flow
+- ❌ Complex state management
+- ❌ Hard to extend with new prompt types
+
+### Key Innovations
+
+1. **Full Note Context** - No truncation means better synthesis questions
+2. **Project Awareness** - Agent checks daily notes for current work
+3. **Dynamic Tool Use** - Agent fetches exactly what it needs
+4. **Adaptive Difficulty** - Adjusts based on review history and note characteristics
+5. **Connection Building** - Agent suggests and creates links during review
+6. **Conversational Flow** - More engaging than rigid forms
+
+### Alignment with Flint Philosophy
+
+- ✅ **AI assists, human thinks** - Agent creates challenge, user does the synthesis
+- ✅ **Agent SDK** - Perfect use case for agentic workflows
+- ✅ **Local-first** - All review data stays local
+- ✅ **Flexible** - Agent adapts to user's note-taking style
+- ✅ **Deep processing** - Forces understanding over recognition
 
 ## Timeline Estimate
 
-**Week 1: Backend**
-- Database schema
-- API endpoints
-- Prompt generation system
+**Week 1: Backend & MCP Tools**
+- Database schema and migrations
+- API endpoints (getNotesForReview, completeReview, etc.)
+- MCP tools for agent (get_note, get_linked_notes, search_daily_notes, etc.)
+- Agent system prompt and review guidelines
 
-**Week 2: Frontend**
-- Review view
-- Enable toggle
-- Review modal
+**Week 2: Frontend & Agent Integration**
+- Review view (list of due notes)
+- Enable review toggle
+- Conversational review interface (chat UI)
+- Agent initialization and context loading
 
 **Week 3: Polish & Testing**
-- Error handling
-- Loading states
-- User testing
-- Bug fixes
+- Error handling and fallbacks
+- Loading states and UX polish
+- User testing with real notes
+- Bug fixes and iteration
 
 **Total: 3 weeks for prototype**
 
+## Next Steps
+
+1. **Review and approve this revised spec**
+2. **Test agent prompt with sample notes** - Validate quality before building UI
+3. **Implement MCP tools** - Get backend ready for agent
+4. **Build conversational UI** - Chat-like review interface
+5. **Test with real users** - Validate the agent-driven approach
+
 ---
 
-**Document Status:** Prototype specification (ready for implementation)
+**Document Status:** Revised prototype specification (agent-driven approach)
 **Created:** 2025-01-15
-**Dependencies:** Requires design decisions to be finalized first
-**Next Step:** Review with team, finalize open decisions, begin implementation
+**Revised:** 2025-01-15 (Major revision: agent-driven review with full context)
+**Key Changes:**
+- Agent chooses review strategy instead of predetermined prompts
+- Full note content instead of truncated summaries
+- Conversational interface instead of rigid modal flow
+- Tool-based context fetching instead of pre-computed context
+**Next Step:** Review with team, test agent prompt, begin implementation


### PR DESCRIPTION
Analyzes 7 different strategies for managing LLM context when generating
synthesis prompts and analyzing user responses. Cannot simply dump all
notes into context due to token limits, cost, and performance concerns.

Key recommendations:
- Use hybrid approach combining markdown-aware extraction with token budgets
- Prompt generation: main note 500 chars, related notes 300 chars (max 3)
- Response analysis: full main note (5k chars), related summaries 400 chars
- Estimated cost: ~$0.0015 per review with Haiku

Includes implementation details, fallback strategies, future optimizations
with embeddings and caching, and comparison table of all options.