### PR TITLE
Clean up gutter plus button styling

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -1,0 +1,7 @@
+{
+  "scripts": {
+    "setup": "npm install",
+    "run": "npm run dev"
+  },
+  "runScriptMode": "nonconcurrent"
+}

--- a/src/renderer/src/components/MainView.svelte
+++ b/src/renderer/src/components/MainView.svelte
@@ -2205,7 +2205,7 @@
     width: 100%;
     max-width: 70ch;
     margin: 0 auto;
-    padding: 0 1rem;
+    padding: 0 1rem 0 1.5rem; /* Extra left padding for gutter plus button */
     min-height: 100%;
   }
 

--- a/src/renderer/src/components/NoteEditor.svelte
+++ b/src/renderer/src/components/NoteEditor.svelte
@@ -1221,7 +1221,7 @@
   .editor-container {
     flex: 1;
     min-height: 300px;
-    overflow: hidden;
+    overflow: visible;
   }
 
   .preview-container {

--- a/src/renderer/src/lib/automerge/gutter-plus-button.svelte.ts
+++ b/src/renderer/src/lib/automerge/gutter-plus-button.svelte.ts
@@ -81,9 +81,25 @@ class PlusButtonMarker extends GutterMarker {
  * CSS theme for the gutter plus button
  */
 const gutterPlusTheme = EditorView.theme({
+  // Make the overall gutters container transparent and borderless
+  // Use longer selector chain for higher specificity to override theme styles
+  '& .cm-scroller .cm-gutters': {
+    background: 'transparent',
+    backgroundColor: 'transparent',
+    color: 'inherit',
+    border: 'none',
+    borderRight: 'none',
+    padding: '0'
+  },
+  // Also ensure the active line gutter has no background
+  '& .cm-scroller .cm-activeLineGutter': {
+    background: 'transparent'
+  },
   '.cm-gutter-plus': {
     width: '24px',
-    flexShrink: '0'
+    flexShrink: '0',
+    background: 'transparent',
+    marginLeft: '-24px'
   },
   '.gutter-plus-button': {
     display: 'flex',


### PR DESCRIPTION
## Summary

Hide gutter background/borders while keeping the plus button visible, and offset the gutter with negative margin to prevent editor content indentation. Add extra left padding to content-wrapper for proper viewport spacing on narrow viewports.

- Gutter uses negative margin to extend left instead of pushing content right
- Transparent backgrounds and removed borders from gutter elements
- Editor container allows overflow to display the gutter
- Extra left padding on content-wrapper ensures spacing when viewport shrinks

🤖 Generated with [Claude Code](https://claude.com/claude-code)