### PR TITLE
Add styled markdown links with editing and click-to-open

### DIFF
--- a/src/renderer/src/components/MarkdownLinkEditPopover.svelte
+++ b/src/renderer/src/components/MarkdownLinkEditPopover.svelte
@@ -1,0 +1,220 @@
+<script lang="ts">
+  /**
+   * Edit popover for markdown links in the editor.
+   * Two input fields: link text and URL.
+   */
+  interface Props {
+    visible: boolean;
+    x: number;
+    y: number;
+    displayText: string;
+    url: string;
+    linkRect: { top: number; bottom: number; left: number; height: number } | null;
+    onSave: (newDisplayText: string, newUrl: string) => void;
+    onCancel: () => void;
+    onCommit?: () => void;
+  }
+
+  let {
+    visible = $bindable(false),
+    x,
+    y,
+    displayText,
+    url,
+    linkRect,
+    onSave,
+    onCancel,
+    onCommit
+  }: Props = $props();
+
+  let textInputValue = $state(displayText);
+  let urlInputValue = $state(url);
+  let textInputElement: HTMLInputElement | undefined = $state();
+  let urlInputElement: HTMLInputElement | undefined = $state();
+  let popoverElement: HTMLDivElement | undefined = $state();
+
+  // Update input values when props change (but only if we're not actively editing)
+  $effect(() => {
+    if (textInputElement !== document.activeElement) {
+      textInputValue = displayText;
+    }
+  });
+
+  $effect(() => {
+    if (urlInputElement !== document.activeElement) {
+      urlInputValue = url;
+    }
+  });
+
+  // Focus the text input when the popover becomes visible
+  $effect(() => {
+    if (visible && textInputElement) {
+      setTimeout(() => {
+        textInputElement?.focus();
+        textInputElement?.select();
+      }, 0);
+    }
+  });
+
+  // Close on click outside
+  $effect(() => {
+    if (!visible) return;
+
+    function handleClickOutside(e: MouseEvent): void {
+      if (popoverElement && !popoverElement.contains(e.target as Node)) {
+        // Save current values before closing if they're valid
+        if (textInputValue.trim() && urlInputValue.trim()) {
+          onSave(textInputValue.trim(), urlInputValue.trim());
+        }
+        onCommit?.();
+      }
+    }
+
+    // Delay adding listener to avoid immediate close from the click that opened it
+    const timeoutId = setTimeout(() => {
+      document.addEventListener('mousedown', handleClickOutside);
+    }, 0);
+
+    return () => {
+      clearTimeout(timeoutId);
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  });
+
+  export function hasFocus(): boolean {
+    return (
+      textInputElement === document.activeElement ||
+      urlInputElement === document.activeElement
+    );
+  }
+
+  // Adjust position when visible to avoid covering the link
+  $effect(() => {
+    if (visible && popoverElement && linkRect) {
+      const rect = popoverElement.getBoundingClientRect();
+      const actualHeight = rect.height;
+
+      // Check if popover is covering the link
+      const popoverBottom = rect.top + actualHeight;
+      const isCoveringLink = rect.top < linkRect.bottom && popoverBottom > linkRect.top;
+
+      if (isCoveringLink) {
+        // Position above the link instead
+        const newY = linkRect.top - 4 - actualHeight;
+        popoverElement.style.top = `${newY}px`;
+      }
+    }
+  });
+
+  function handleInput(): void {
+    if (textInputValue.trim() && urlInputValue.trim()) {
+      onSave(textInputValue.trim(), urlInputValue.trim());
+    }
+  }
+
+  function handleKeydown(e: KeyboardEvent): void {
+    if (!visible) return;
+
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      e.stopPropagation();
+      onCancel();
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      e.stopPropagation();
+      // Commit the current values and close
+      if (textInputValue.trim() && urlInputValue.trim()) {
+        onSave(textInputValue.trim(), urlInputValue.trim());
+      }
+      onCommit?.();
+    }
+  }
+</script>
+
+{#if visible}
+  <div
+    bind:this={popoverElement}
+    class="markdown-link-popover"
+    style="left: {x}px; top: {y}px;"
+  >
+    <div class="popover-content">
+      <div class="input-group">
+        <label for="text-input">Text</label>
+        <input
+          id="text-input"
+          type="text"
+          bind:this={textInputElement}
+          bind:value={textInputValue}
+          oninput={handleInput}
+          onkeydown={handleKeydown}
+          placeholder="Link text"
+        />
+      </div>
+      <div class="input-group">
+        <label for="url-input">URL</label>
+        <input
+          id="url-input"
+          type="text"
+          bind:this={urlInputElement}
+          bind:value={urlInputValue}
+          oninput={handleInput}
+          onkeydown={handleKeydown}
+          placeholder="https://example.com"
+        />
+      </div>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .markdown-link-popover {
+    position: fixed;
+    z-index: 1000;
+    background: var(--bg-primary);
+    border: 1px solid var(--border-medium);
+    border-radius: 0.375rem;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    padding: 0.75rem;
+    min-width: 320px;
+    max-width: 450px;
+  }
+
+  .popover-content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .input-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  label {
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: var(--text-secondary);
+  }
+
+  input[type='text'] {
+    font-size: 0.8125rem;
+    padding: 0.5rem 0.75rem;
+    border: 1px solid var(--border-medium);
+    border-radius: 0.25rem;
+    outline: none;
+    transition: border-color 0.15s;
+    width: 100%;
+    background: var(--bg-primary);
+    color: var(--text-primary);
+  }
+
+  input[type='text']:focus {
+    border-color: var(--accent-primary);
+    box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+  }
+
+  input[type='text']::placeholder {
+    color: var(--text-secondary);
+  }
+</style>

--- a/src/renderer/src/components/WikilinkActionPopover.svelte
+++ b/src/renderer/src/components/WikilinkActionPopover.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   /**
-   * Action popover for wikilinks in the Automerge editor.
-   * Shows actions: Open note, Edit display text
+   * Action popover for wikilinks and markdown links in the Automerge editor.
+   * Shows actions: Open note/link, Edit display text/link
    */
   interface Props {
     visible: boolean;
@@ -10,9 +10,18 @@
     linkRect: { top: number; bottom: number; left: number; height: number } | null;
     onOpen: () => void;
     onEdit: () => void;
+    editLabel?: string;
   }
 
-  let { visible = $bindable(false), x, y, linkRect, onOpen, onEdit }: Props = $props();
+  let {
+    visible = $bindable(false),
+    x,
+    y,
+    linkRect,
+    onOpen,
+    onEdit,
+    editLabel = 'Edit Display Text'
+  }: Props = $props();
 
   let popoverElement: HTMLDivElement | undefined = $state();
 
@@ -94,7 +103,7 @@
         <path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"></path>
         <path d="m15 5 4 4"></path>
       </svg>
-      <span>Edit Display Text</span>
+      <span>{editLabel}</span>
       <kbd>{altKey}↵</kbd>
     </button>
   </div>

--- a/src/renderer/src/lib/automerge/editorConfig.svelte.ts
+++ b/src/renderer/src/lib/automerge/editorConfig.svelte.ts
@@ -24,6 +24,12 @@ import {
   type WikilinkHoverHandler,
   type WikilinkEditDisplayTextHandler
 } from './wikilinks.svelte';
+import {
+  markdownLinksExtension,
+  type MarkdownLinkClickHandler,
+  type MarkdownLinkHoverHandler,
+  type MarkdownLinkEditHandler
+} from './markdown-links.svelte';
 import { deckExtension } from './deck';
 import { imageExtension } from './image-extension.svelte';
 import { richPasteExtension } from './rich-paste-extension.svelte';
@@ -54,6 +60,12 @@ export interface EditorConfigOptions {
   onWikilinkHover?: WikilinkHoverHandler;
   /** Handler for editing wikilink display text (Alt-Enter) */
   onWikilinkEditDisplayText?: WikilinkEditDisplayTextHandler;
+  /** Handler for clicking markdown links - opens external URL */
+  onMarkdownLinkClick?: MarkdownLinkClickHandler;
+  /** Handler for hovering over markdown links */
+  onMarkdownLinkHover?: MarkdownLinkHoverHandler;
+  /** Handler for editing markdown links (Alt-Enter) */
+  onMarkdownLinkEdit?: MarkdownLinkEditHandler;
   /** @deprecated Use automergeSync instead for CRDT text editing */
   onContentChange?: (content: string) => void;
   onCursorChange?: () => void;
@@ -189,6 +201,16 @@ export class EditorConfig {
               this.options.onWikilinkClick,
               this.options.onWikilinkHover,
               this.options.onWikilinkEditDisplayText
+            )
+          ]
+        : []),
+      // Markdown links extension
+      ...(this.options.onMarkdownLinkClick
+        ? [
+            markdownLinksExtension(
+              this.options.onMarkdownLinkClick,
+              this.options.onMarkdownLinkHover,
+              this.options.onMarkdownLinkEdit
             )
           ]
         : []),

--- a/src/renderer/src/lib/automerge/index.ts
+++ b/src/renderer/src/lib/automerge/index.ts
@@ -452,6 +452,22 @@ export type {
   SelectedWikilink
 } from './wikilinks.svelte';
 
+// Markdown links support
+export {
+  markdownLinksExtension,
+  forceMarkdownLinkRefresh,
+  getSelectedMarkdownLink,
+  parseMarkdownLinks
+} from './markdown-links.svelte';
+export type {
+  MarkdownLinkMatch,
+  MarkdownLinkClickHandler,
+  MarkdownLinkHoverHandler,
+  MarkdownLinkEditHandler,
+  MarkdownLinkHoverData,
+  SelectedMarkdownLink
+} from './markdown-links.svelte';
+
 // Wikilink stabilization (convert title-based links to ID-based)
 export {
   stabilizeWikilinksInContent,

--- a/src/renderer/src/lib/automerge/markdown-links.svelte.ts
+++ b/src/renderer/src/lib/automerge/markdown-links.svelte.ts
@@ -1,0 +1,565 @@
+/**
+ * Markdown links extension for CodeMirror
+ *
+ * Provides styled, interactive rendering of markdown links [text](url)
+ * with atomic cursor movement, click-to-open, and alt+enter editing.
+ */
+import { EditorView, Decoration, WidgetType } from '@codemirror/view';
+import type { DecorationSet } from '@codemirror/view';
+import {
+  StateField,
+  StateEffect,
+  RangeSet,
+  RangeValue,
+  EditorState,
+  Prec,
+  type Extension,
+  type Range
+} from '@codemirror/state';
+import { keymap } from '@codemirror/view';
+import { syntaxTree } from '@codemirror/language';
+
+import { markdownLinkTheme } from '../markdown-link-theme';
+
+// Regex to match markdown links [text](url)
+// Negative lookbehind excludes images ![...] and wikilinks [[...]]
+// URL part handles balanced parentheses (one level) for URLs like Wikipedia
+// e.g., https://en.wikipedia.org/wiki/Parenthesis_(disambiguation)
+// eslint-disable-next-line no-useless-escape
+const MARKDOWN_LINK_REGEX = /(?<![!\[])\[([^\[\]]+)\]\(((?:[^()]|\([^()]*\))+)\)/g;
+
+export interface MarkdownLinkMatch {
+  from: number;
+  to: number;
+  text: string; // Full match: [display](url)
+  displayText: string; // Text inside brackets
+  url: string; // URL inside parentheses
+}
+
+export interface SelectedMarkdownLink {
+  from: number;
+  to: number;
+  displayText: string;
+  url: string;
+}
+
+export type MarkdownLinkClickHandler = (url: string) => void;
+
+export interface MarkdownLinkHoverData {
+  displayText: string;
+  url: string;
+  from: number;
+  to: number;
+  x: number;
+  y: number;
+  yTop: number;
+}
+
+export type MarkdownLinkHoverHandler = (data: MarkdownLinkHoverData | null) => void;
+export type MarkdownLinkEditHandler = (link: SelectedMarkdownLink) => void;
+
+// Effects
+const setMarkdownLinkHandler = StateEffect.define<MarkdownLinkClickHandler>();
+const setMarkdownLinkHoverHandler = StateEffect.define<MarkdownLinkHoverHandler>();
+const forceMarkdownLinkUpdate = StateEffect.define<boolean>();
+
+/**
+ * Extract the URL from a markdown link target that may include a title.
+ * Handles formats like:
+ * - url
+ * - url "title"
+ * - url 'title'
+ * - url (title)
+ * - <url>
+ * - <url> "title"
+ */
+function extractUrl(linkTarget: string): string {
+  const trimmed = linkTarget.trim();
+
+  // Handle angle brackets: <url> or <url> "title"
+  if (trimmed.startsWith('<')) {
+    const closeAngle = trimmed.indexOf('>');
+    if (closeAngle !== -1) {
+      return trimmed.substring(1, closeAngle);
+    }
+  }
+
+  // Look for title delimiter: space followed by " or ' or (
+  const titleStart = trimmed.search(/\s+["'(]/);
+  if (titleStart !== -1) {
+    return trimmed.substring(0, titleStart);
+  }
+
+  // No title, return the whole thing
+  return trimmed;
+}
+
+/**
+ * Parse markdown links from text content
+ */
+export function parseMarkdownLinks(text: string): MarkdownLinkMatch[] {
+  const matches: MarkdownLinkMatch[] = [];
+
+  MARKDOWN_LINK_REGEX.lastIndex = 0;
+
+  let match;
+  while ((match = MARKDOWN_LINK_REGEX.exec(text)) !== null) {
+    matches.push({
+      from: match.index,
+      to: match.index + match[0].length,
+      text: match[0],
+      displayText: match[1],
+      url: extractUrl(match[2])
+    });
+  }
+
+  return matches;
+}
+
+// State field to store the currently selected markdown link (cursor adjacent to it)
+const selectedMarkdownLinkField = StateField.define<SelectedMarkdownLink | null>({
+  create: () => null,
+  update: (value, tr) => {
+    if (!tr.docChanged && !tr.selection) {
+      return value;
+    }
+
+    const cursorPos = tr.state.selection.main.head;
+    const text = tr.state.doc.toString();
+    const links = parseMarkdownLinks(text);
+
+    for (const link of links) {
+      if (cursorPos === link.from || cursorPos === link.to) {
+        return {
+          from: link.from,
+          to: link.to,
+          displayText: link.displayText,
+          url: link.url
+        };
+      }
+    }
+
+    return null;
+  }
+});
+
+// State field to store the click handler
+const markdownLinkHandlerField = StateField.define<MarkdownLinkClickHandler | null>({
+  create: () => null,
+  update: (value, tr) => {
+    for (const effect of tr.effects) {
+      if (effect.is(setMarkdownLinkHandler)) {
+        return effect.value;
+      }
+    }
+    return value;
+  }
+});
+
+// State field to store the hover handler
+const markdownLinkHoverHandlerField = StateField.define<MarkdownLinkHoverHandler | null>({
+  create: () => null,
+  update: (value, tr) => {
+    for (const effect of tr.effects) {
+      if (effect.is(setMarkdownLinkHoverHandler)) {
+        return effect.value;
+      }
+    }
+    return value;
+  }
+});
+
+// State field to store the edit handler
+const markdownLinkEditHandlerField = StateField.define<MarkdownLinkEditHandler | null>({
+  create: () => null,
+  update: (v) => v
+});
+
+/**
+ * RangeValue for atomic cursor movement over markdown links
+ */
+class AtomicRangeValue extends RangeValue {
+  eq(other: RangeValue): boolean {
+    return other instanceof AtomicRangeValue;
+  }
+}
+const atomicValue = new AtomicRangeValue();
+
+/**
+ * Widget for rendering clickable markdown links with inline text flow
+ */
+class MarkdownLinkWidget extends WidgetType {
+  constructor(
+    private displayText: string,
+    private url: string,
+    private clickHandler: MarkdownLinkClickHandler | null,
+    private hoverHandler: MarkdownLinkHoverHandler | null,
+    private from: number,
+    private to: number,
+    private isSelected: boolean
+  ) {
+    super();
+  }
+
+  toDOM(_view: EditorView): HTMLElement {
+    const container = document.createElement('span');
+
+    // Build class name
+    const classes = ['markdown-link'];
+    if (this.isSelected) {
+      classes.push('markdown-link-selected');
+    }
+    container.className = classes.join(' ');
+
+    // Click handler - open external URL
+    const handleClick = (e: MouseEvent): void => {
+      e.preventDefault();
+      e.stopPropagation();
+      this.clickHandler?.(this.url);
+    };
+
+    // Prevent editor from handling mousedown
+    const handleMouseDown = (e: MouseEvent): void => {
+      e.stopPropagation();
+    };
+
+    // Track hover state
+    let isHovering = false;
+
+    // Calculate bounding rect using getClientRects for proper multi-line support
+    const getMarkdownLinkBoundingRect = (): DOMRect => {
+      const segmentSpan = container.querySelector('.markdown-link-segment');
+      if (!segmentSpan) {
+        return container.getBoundingClientRect();
+      }
+
+      const rects = segmentSpan.getClientRects();
+      if (rects.length === 0) {
+        return segmentSpan.getBoundingClientRect();
+      }
+
+      const firstRect = rects[0];
+      const lastRect = rects[rects.length - 1];
+
+      return new DOMRect(
+        lastRect.left,
+        firstRect.top,
+        lastRect.width,
+        lastRect.bottom - firstRect.top
+      );
+    };
+
+    const handleMouseEnter = (): void => {
+      if (isHovering || !this.hoverHandler) return;
+      isHovering = true;
+
+      const rect = getMarkdownLinkBoundingRect();
+      this.hoverHandler({
+        displayText: this.displayText,
+        url: this.url,
+        from: this.from,
+        to: this.to,
+        x: rect.left,
+        y: rect.bottom,
+        yTop: rect.top
+      });
+    };
+
+    const handleMouseLeave = (e: MouseEvent): void => {
+      if (!this.hoverHandler) return;
+      const relatedTarget = e.relatedTarget as Element | null;
+      if (relatedTarget && container.contains(relatedTarget)) {
+        return;
+      }
+
+      isHovering = false;
+      this.hoverHandler(null);
+    };
+
+    // Outer span for background/styling (no underline)
+    const segmentSpan = document.createElement('span');
+    segmentSpan.className = 'markdown-link-segment';
+
+    // Inner span for display text (with underline)
+    const textSpan = document.createElement('span');
+    textSpan.className = 'markdown-link-text';
+    const text = this.displayText || 'Link';
+    textSpan.appendChild(document.createTextNode(text));
+    segmentSpan.appendChild(textSpan);
+
+    // Icon wrapper (no underline) - keeps icon with last word
+    const iconWrapper = document.createElement('span');
+    iconWrapper.className = 'markdown-link-icon-wrapper';
+    iconWrapper.style.whiteSpace = 'nowrap';
+
+    // Non-breaking space before icon
+    iconWrapper.appendChild(document.createTextNode('\u00A0'));
+
+    // Icon span
+    const iconSpan = document.createElement('span');
+    iconSpan.className = 'markdown-link-icon';
+    iconSpan.textContent = '\u{1F517}'; // Link emoji
+    iconWrapper.appendChild(iconSpan);
+
+    segmentSpan.appendChild(iconWrapper);
+
+    // Trailing anchor for cursor positioning when widget wraps
+    const cursorAnchor = document.createElement('span');
+    cursorAnchor.className = 'markdown-link-cursor-anchor';
+    cursorAnchor.textContent = '\u200B'; // Zero-width space
+    segmentSpan.appendChild(cursorAnchor);
+
+    // Attach event handlers to the segment span
+    segmentSpan.addEventListener('click', handleClick);
+    segmentSpan.addEventListener('mousedown', handleMouseDown);
+    segmentSpan.addEventListener('mouseenter', handleMouseEnter);
+    segmentSpan.addEventListener('mouseleave', handleMouseLeave);
+
+    container.appendChild(segmentSpan);
+
+    return container;
+  }
+
+  eq(other: MarkdownLinkWidget): boolean {
+    return (
+      this.displayText === other.displayText &&
+      this.url === other.url &&
+      this.isSelected === other.isSelected
+    );
+  }
+
+  ignoreEvent(): boolean {
+    return true;
+  }
+
+  // Override to provide cursor coordinates since container uses display:contents
+  coordsAt(
+    dom: HTMLElement,
+    pos: number,
+    side: number
+  ): { top: number; bottom: number; left: number; right: number } | null {
+    const segmentSpan = dom.querySelector('.markdown-link-segment');
+    if (!segmentSpan) return null;
+
+    const rects = segmentSpan.getClientRects();
+    if (rects.length === 0) return null;
+
+    const firstRect = rects[0];
+    const lastRect = rects[rects.length - 1];
+    const widgetLength = this.to - this.from;
+
+    const atEnd = pos >= widgetLength - 1 || (pos > widgetLength / 2 && side >= 0);
+    const atStart = pos === 0 && side <= 0;
+
+    if (atEnd && !atStart) {
+      return {
+        top: lastRect.top,
+        bottom: lastRect.bottom,
+        left: lastRect.right,
+        right: lastRect.right
+      };
+    } else {
+      return {
+        top: firstRect.top,
+        bottom: firstRect.bottom,
+        left: firstRect.left,
+        right: firstRect.left
+      };
+    }
+  }
+}
+
+/**
+ * Check if a position is inside a code context
+ */
+function isInCodeContext(state: EditorState, pos: number): boolean {
+  const tree = syntaxTree(state);
+  let inCode = false;
+
+  tree.iterate({
+    from: pos,
+    to: pos,
+    enter: (node) => {
+      const name = node.name;
+      if (
+        name === 'InlineCode' ||
+        name === 'CodeBlock' ||
+        name === 'FencedCode' ||
+        name === 'CodeText' ||
+        name === 'CodeInfo' ||
+        name === 'CodeMark'
+      ) {
+        inCode = true;
+        return false;
+      }
+      return undefined;
+    }
+  });
+
+  return inCode;
+}
+
+/**
+ * Create markdown link decorations for the document
+ */
+function createMarkdownLinkDecorations(
+  state: EditorState,
+  clickHandler: MarkdownLinkClickHandler | null,
+  hoverHandler: MarkdownLinkHoverHandler | null
+): DecorationSet {
+  const decorations: Range<Decoration>[] = [];
+  const text = state.doc.toString();
+  const links = parseMarkdownLinks(text);
+  const selectedLink = state.field(selectedMarkdownLinkField);
+
+  for (const link of links) {
+    // Skip links inside code blocks
+    if (isInCodeContext(state, link.from)) {
+      continue;
+    }
+
+    const isSelected =
+      selectedLink !== null &&
+      selectedLink.from === link.from &&
+      selectedLink.to === link.to;
+
+    const widget = new MarkdownLinkWidget(
+      link.displayText,
+      link.url,
+      clickHandler,
+      hoverHandler,
+      link.from,
+      link.to,
+      isSelected
+    );
+
+    decorations.push(
+      Decoration.replace({
+        widget,
+        inclusive: false,
+        block: false
+      }).range(link.from, link.to)
+    );
+  }
+
+  return RangeSet.of(decorations.sort((a, b) => a.from - b.from));
+}
+
+// State field for markdown link decorations
+const markdownLinkField = StateField.define<DecorationSet>({
+  create: (state) => {
+    const handler = state.field(markdownLinkHandlerField);
+    const hoverHandler = state.field(markdownLinkHoverHandlerField);
+    return createMarkdownLinkDecorations(state, handler, hoverHandler);
+  },
+  update: (decorations, tr) => {
+    // Check for force update effect
+    for (const effect of tr.effects) {
+      if (effect.is(forceMarkdownLinkUpdate)) {
+        const handler = tr.state.field(markdownLinkHandlerField);
+        const hoverHandler = tr.state.field(markdownLinkHoverHandlerField);
+        return createMarkdownLinkDecorations(tr.state, handler, hoverHandler);
+      }
+    }
+
+    // Only recalculate if document changed or selection changed
+    if (tr.docChanged || tr.selection) {
+      const handler = tr.state.field(markdownLinkHandlerField);
+      const hoverHandler = tr.state.field(markdownLinkHoverHandlerField);
+      return createMarkdownLinkDecorations(tr.state, handler, hoverHandler);
+    }
+
+    return decorations;
+  },
+  provide: (field) => EditorView.decorations.from(field)
+});
+
+/**
+ * Force refresh markdown links (call when needed externally)
+ */
+export function forceMarkdownLinkRefresh(view: EditorView): void {
+  view.dispatch({
+    effects: forceMarkdownLinkUpdate.of(true)
+  });
+}
+
+/**
+ * Get selected markdown link from state
+ */
+export function getSelectedMarkdownLink(view: EditorView): SelectedMarkdownLink | null {
+  return view.state.field(selectedMarkdownLinkField);
+}
+
+/**
+ * Create the markdown links extension
+ */
+export function markdownLinksExtension(
+  onLinkClick: MarkdownLinkClickHandler,
+  onLinkHover?: MarkdownLinkHoverHandler,
+  onLinkEdit?: MarkdownLinkEditHandler
+): Extension {
+  const markdownLinkKeymap = Prec.highest(
+    keymap.of([
+      // Mod-Enter to open URL in external browser
+      {
+        key: 'Mod-Enter',
+        run: (view) => {
+          const selected = view.state.field(selectedMarkdownLinkField);
+          if (selected) {
+            const handler = view.state.field(markdownLinkHandlerField);
+            handler?.(selected.url);
+            return true;
+          }
+          return false;
+        }
+      },
+      // Alt-Enter to edit markdown link
+      {
+        key: 'Alt-Enter',
+        run: (view) => {
+          const selected = view.state.field(selectedMarkdownLinkField);
+          if (selected) {
+            const handler = view.state.field(markdownLinkEditHandlerField);
+            if (handler) {
+              handler(selected);
+              return true;
+            }
+          }
+          return false;
+        }
+      }
+    ])
+  );
+
+  return [
+    markdownLinkTheme,
+    markdownLinkHandlerField.init(() => onLinkClick),
+    markdownLinkHoverHandlerField.init(() => onLinkHover || null),
+    markdownLinkEditHandlerField.init(() => onLinkEdit || null),
+    selectedMarkdownLinkField,
+    markdownLinkField,
+    markdownLinkKeymap,
+    // Add atomic ranges for proper cursor movement (cursor jumps over widget as unit)
+    EditorView.atomicRanges.of((view) => {
+      const decorations = view.state.field(markdownLinkField, false);
+      if (!decorations) {
+        return RangeSet.empty;
+      }
+
+      const ranges: ReturnType<typeof atomicValue.range>[] = [];
+
+      try {
+        decorations.between(0, view.state.doc.length, (from, to, value) => {
+          if (value.spec.widget instanceof MarkdownLinkWidget) {
+            ranges.push(atomicValue.range(from, to));
+          }
+        });
+
+        return ranges.length > 0 ? RangeSet.of(ranges) : RangeSet.empty;
+      } catch (e) {
+        console.warn('Error creating atomic ranges:', e);
+        return RangeSet.empty;
+      }
+    })
+  ];
+}

--- a/src/renderer/src/lib/automerge/markdown-links.svelte.ts
+++ b/src/renderer/src/lib/automerge/markdown-links.svelte.ts
@@ -292,9 +292,6 @@ class MarkdownLinkWidget extends WidgetType {
     iconWrapper.className = 'markdown-link-icon-wrapper';
     iconWrapper.style.whiteSpace = 'nowrap';
 
-    // Non-breaking space before icon
-    iconWrapper.appendChild(document.createTextNode('\u00A0'));
-
     // Icon span
     const iconSpan = document.createElement('span');
     iconSpan.className = 'markdown-link-icon';

--- a/src/renderer/src/lib/markdown-link-theme.ts
+++ b/src/renderer/src/lib/markdown-link-theme.ts
@@ -1,0 +1,77 @@
+import { EditorView } from '@codemirror/view';
+
+/**
+ * CodeMirror theme for markdown links with inline text flow.
+ * Uses blue color scheme to distinguish from wikilinks.
+ */
+export const markdownLinkTheme = EditorView.theme({
+  '.markdown-link': {
+    display: 'contents' // No box - children flow inline with surrounding text
+  },
+
+  '.markdown-link-segment': {
+    cursor: 'pointer',
+    display: 'inline',
+    fontWeight: '600',
+    transition: 'all 0.15s ease',
+    padding: '0.1em 0.2em',
+    borderRadius: '0.25em',
+    boxDecorationBreak: 'clone', // Consistent styling across line breaks
+    WebkitBoxDecorationBreak: 'clone'
+  },
+
+  '.markdown-link-icon-wrapper': {
+    display: 'inline',
+    textDecoration: 'none' // No underline for space and icon
+  },
+
+  '.markdown-link-icon': {
+    display: 'inline-block',
+    fontSize: '0.9em',
+    lineHeight: '1',
+    textDecoration: 'none'
+  },
+
+  '.markdown-link-text': {
+    display: 'inline',
+    textDecoration: 'underline',
+    textDecorationThickness: '1px',
+    textUnderlineOffset: '2px',
+    wordBreak: 'break-word' // Allow very long words to break
+  },
+
+  // Default state - blue tones for external links
+  '.markdown-link .markdown-link-segment': {
+    background: 'rgba(59, 130, 246, 0.08)',
+    color: '#2563eb'
+  },
+
+  '.markdown-link .markdown-link-segment:hover': {
+    background: 'rgba(59, 130, 246, 0.15)',
+    color: '#1d4ed8'
+  },
+
+  // Selected state
+  '.markdown-link-selected .markdown-link-segment': {
+    background: 'rgba(59, 130, 246, 0.15)',
+    color: '#1d4ed8'
+  },
+
+  // Dark mode using CSS media queries
+  '@media (prefers-color-scheme: dark)': {
+    '.markdown-link .markdown-link-segment': {
+      background: 'rgba(96, 165, 250, 0.12)',
+      color: '#60a5fa'
+    },
+
+    '.markdown-link .markdown-link-segment:hover': {
+      background: 'rgba(96, 165, 250, 0.2)',
+      color: '#93c5fd'
+    },
+
+    '.markdown-link-selected .markdown-link-segment': {
+      background: 'rgba(96, 165, 250, 0.2)',
+      color: '#93c5fd'
+    }
+  }
+});

--- a/src/renderer/src/lib/markdown-link-theme.ts
+++ b/src/renderer/src/lib/markdown-link-theme.ts
@@ -22,13 +22,14 @@ export const markdownLinkTheme = EditorView.theme({
 
   '.markdown-link-icon-wrapper': {
     display: 'inline',
-    textDecoration: 'none' // No underline for space and icon
+    textDecoration: 'none', // No underline for space and icon
+    marginLeft: '0.25em' // Explicit spacing from text
   },
 
   '.markdown-link-icon': {
-    display: 'inline-block',
-    fontSize: '0.9em',
-    lineHeight: '1',
+    display: 'inline',
+    fontSize: '0.85em',
+    verticalAlign: 'baseline',
     textDecoration: 'none'
   },
 


### PR DESCRIPTION
## Summary

Implements markdown link rendering with styled widgets, atomic cursor movement, click-to-open in external browser, and a comprehensive edit interface. Links are displayed as interactive elements with a blue background and underline.

## Features

- **Styled rendering**: Blue background and underline with link emoji icon
- **Atomic cursor**: Arrow keys jump over entire link as single unit
- **Click-to-open**: Opens URLs in external browser (Electron/web)
- **Hover actions**: "Open" and "Edit Link" buttons appear on hover
- **Smart editing**: Alt+Enter opens two-field editor for link text and URL
- **URL parsing**: Handles titles (`url "title"`), parentheses in URLs, and angle brackets
- **UX polish**: Click-outside closes editor, no underline on icon spacing

## Test Plan

- [x] Create markdown link `[text](url)` - renders as styled widget
- [x] Arrow keys jump over link atomically
- [x] Click to open URL in external browser
- [x] Hover to see action popover
- [x] Alt+Enter to edit link text and URL
- [x] Links with titles: `[text](url "title")` work correctly
- [x] Wikipedia URLs: `[text](https://en.wikipedia.org/wiki/Term_(category))` work
- [x] Click outside edit popover to close it
- [x] Icon spacing doesn't have underline

🤖 Generated with [Claude Code](https://claude.com/claude-code)