### PR TITLE
Fix sidebar resize handle blocking in drag regions

### DIFF
--- a/src/renderer/src/components/LeftSidebar.svelte
+++ b/src/renderer/src/components/LeftSidebar.svelte
@@ -297,7 +297,6 @@
   class:mobile-open={mobileDrawerOpen}
   style="--sidebar-width: {currentWidth}px"
 >
-  <ResizeHandle side="left" onResize={handleResize} minWidth={200} maxWidth={600} />
   <div class="sidebar-inner">
     <!-- Header row with traffic light space, vault switcher, and sidebar toggle -->
     {#if !isMobile}
@@ -639,6 +638,7 @@
     </div>
     <WorkspaceBar {onCreateNote} {onCreateDeck} {onCaptureWebpage} {showShadow} />
   </div>
+  <ResizeHandle side="left" onResize={handleResize} minWidth={200} maxWidth={600} />
 </div>
 
 <style>

--- a/src/renderer/src/components/ResizeHandle.svelte
+++ b/src/renderer/src/components/ResizeHandle.svelte
@@ -95,6 +95,7 @@
     user-select: none;
     z-index: 100;
     background-color: transparent;
+    -webkit-app-region: no-drag;
   }
 
   .resize-handle.left {


### PR DESCRIPTION
## Summary
Fixed the sidebar resize handle not responding to drag events in the header and workspace bar areas. The issue was caused by Electron's `-webkit-app-region` hit-testing prioritizing DOM order over CSS z-index.

## Changes
- Moved ResizeHandle to last child of left-sidebar so its `no-drag` region takes precedence
- Added `-webkit-app-region: no-drag` to the resize handle CSS for explicit hit-test exclusion

The resize handle now works across the entire sidebar height, including the previously problematic header and workspace bar regions.

🤖 Generated with Claude Code