### PR TITLE
Implement saved searches as first-class entities

### DIFF
--- a/src/renderer/src/components/ExpandedSearchView.svelte
+++ b/src/renderer/src/components/ExpandedSearchView.svelte
@@ -1,0 +1,709 @@
+<script lang="ts">
+  /**
+   * Expanded Search View - shows all search results with all matches per note
+   * in a collapsible format. Uses CodeMirror editors for each match line.
+   */
+  import { onMount, untrack } from 'svelte';
+  import { SvelteSet } from 'svelte/reactivity';
+  import type {
+    NoteMetadata,
+    NoteType,
+    EnhancedSearchResult,
+    WikilinkClickHandler
+  } from '../lib/automerge';
+  import {
+    searchNotesAsync,
+    searchIndex,
+    getNoteContent,
+    getNoteType,
+    setActiveItem,
+    createSavedSearch,
+    updateSavedSearch,
+    getSavedSearch
+  } from '../lib/automerge';
+  import SearchMatchEditor from './SearchMatchEditor.svelte';
+
+  interface Props {
+    searchQuery: string;
+    allNotes: NoteMetadata[];
+    noteTypes: Record<string, NoteType>;
+    onClose: () => void;
+    onSelect: (note: NoteMetadata) => void;
+    /** Optional saved search ID when viewing an existing saved search */
+    savedSearchId?: string;
+  }
+
+  let {
+    searchQuery: initialQuery,
+    allNotes,
+    noteTypes,
+    onClose,
+    onSelect,
+    savedSearchId
+  }: Props = $props();
+
+  /**
+   * Handle wikilink click - navigate to the linked note
+   */
+  const handleWikilinkClick: WikilinkClickHandler = (targetId) => {
+    setActiveItem({ type: 'note', id: targetId });
+    onClose();
+  };
+
+  // State
+  let expandedResults = $state<EnhancedSearchResult[]>([]);
+  let isLoading = $state(true);
+  let expandedNotes = new SvelteSet<string>();
+
+  // Local editable query state
+  let localQuery = $state(initialQuery);
+  let searchInputRef = $state<HTMLInputElement | null>(null);
+
+  // The query used for actual searching (debounced)
+  let activeQuery = $state(initialQuery);
+
+  // Debounce search query changes
+  $effect(() => {
+    const query = localQuery;
+    const timer = setTimeout(() => {
+      activeQuery = query;
+    }, 200);
+    return () => clearTimeout(timer);
+  });
+
+  // Check if this is a saved search
+  const savedSearch = $derived(savedSearchId ? getSavedSearch(savedSearchId) : undefined);
+  const isSaved = $derived(!!savedSearch);
+
+  // Sync query changes to saved search (with debounce)
+  $effect(() => {
+    if (!savedSearchId || !activeQuery.trim()) return;
+
+    // Capture values to use in timeout (avoid accessing reactive vars after cleanup)
+    const searchId = savedSearchId;
+    const query = activeQuery;
+    // Generate title from query (same logic as createSavedSearch)
+    const title = query.length > 50 ? query.slice(0, 47) + '...' : query;
+
+    const timer = setTimeout(() => {
+      // Update the saved search with new query and title
+      updateSavedSearch(searchId, { query, title });
+    }, 500);
+
+    // Cleanup timer when effect re-runs or component unmounts
+    return () => clearTimeout(timer);
+  });
+
+  /**
+   * Save the current search as a new saved search
+   */
+  function handleSaveSearch(): void {
+    if (!activeQuery.trim()) return;
+
+    // Create a new saved search (title auto-generated from query)
+    const id = createSavedSearch({ query: activeQuery });
+
+    // Set as active item to show in sidebar
+    setActiveItem({ type: 'saved-search', id });
+  }
+
+  // Focus the search input on mount
+  onMount(() => {
+    // Small delay to ensure DOM is ready
+    setTimeout(() => {
+      searchInputRef?.focus();
+      searchInputRef?.select();
+    }, 50);
+  });
+
+  // Load results when activeQuery changes or when search index finishes building
+  // Use untrack to prevent tracking allNotes/noteTypes props, which would cause
+  // unnecessary re-runs when those props get new object references
+  $effect(() => {
+    // Track searchIndex.isBuilding - when it becomes false, re-run the search
+    // This handles the case where saved search opens before index is ready
+    void searchIndex.isBuilding;
+
+    if (activeQuery.trim()) {
+      untrack(() => loadExpandedResults());
+    } else {
+      expandedResults = [];
+      isLoading = false;
+    }
+  });
+
+  async function loadExpandedResults(): Promise<void> {
+    isLoading = true;
+    expandedNotes.clear();
+
+    try {
+      const results = await searchNotesAsync(
+        allNotes,
+        activeQuery,
+        {
+          noteTypes,
+          contentLoader: getNoteContent,
+          maxMatchesPerNote: 100,
+          maxResults: 100
+        },
+        searchIndex
+      );
+      expandedResults = results;
+      // Start with all results collapsed for performance
+    } catch (error) {
+      console.error('Error loading expanded search results:', error);
+      expandedResults = [];
+    }
+
+    isLoading = false;
+  }
+
+  function toggleNote(noteId: string): void {
+    if (expandedNotes.has(noteId)) {
+      expandedNotes.delete(noteId);
+    } else {
+      expandedNotes.add(noteId);
+    }
+  }
+
+  function expandAll(): void {
+    for (const result of expandedResults) {
+      expandedNotes.add(result.note.id);
+    }
+  }
+
+  function collapseAll(): void {
+    expandedNotes.clear();
+  }
+
+  function handleNoteClick(note: NoteMetadata): void {
+    onSelect(note);
+  }
+
+  function getNoteIcon(note: NoteMetadata): string {
+    if (note.type) {
+      const noteType = getNoteType(note.type);
+      return noteType?.icon || '📝';
+    }
+    return '📝';
+  }
+
+  /**
+   * Get total match count for a result
+   */
+  function getMatchCount(result: EnhancedSearchResult): number {
+    return result.contentMatches.length + result.titleMatches.length;
+  }
+</script>
+
+<div class="expanded-search-view">
+  <!-- Header -->
+  <div class="search-header">
+    <div class="header-left">
+      <div class="search-input-wrapper">
+        <svg
+          class="search-icon"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <circle cx="11" cy="11" r="8"></circle>
+          <path d="m21 21-4.3-4.3"></path>
+        </svg>
+        <input
+          bind:this={searchInputRef}
+          bind:value={localQuery}
+          type="text"
+          class="search-input"
+          placeholder="Search..."
+          aria-label="Search query"
+        />
+      </div>
+      {#if !isLoading}
+        <span class="result-count">{expandedResults.length} notes</span>
+      {/if}
+    </div>
+    <div class="header-controls">
+      {#if isSaved}
+        <span class="saved-indicator" title="This search is saved">
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            stroke="none"
+          >
+            <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"></path>
+          </svg>
+        </span>
+      {:else}
+        <button
+          class="control-btn save-btn"
+          onclick={handleSaveSearch}
+          title="Save search"
+          aria-label="Save search"
+          disabled={!activeQuery.trim()}
+        >
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"></path>
+          </svg>
+        </button>
+      {/if}
+      <button
+        class="control-btn"
+        onclick={expandAll}
+        title="Expand all"
+        aria-label="Expand all"
+      >
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <polyline points="7 13 12 18 17 13"></polyline>
+          <polyline points="7 6 12 11 17 6"></polyline>
+        </svg>
+      </button>
+      <button
+        class="control-btn"
+        onclick={collapseAll}
+        title="Collapse all"
+        aria-label="Collapse all"
+      >
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <polyline points="17 11 12 6 7 11"></polyline>
+          <polyline points="17 18 12 13 7 18"></polyline>
+        </svg>
+      </button>
+      <button class="close-btn" onclick={onClose} title="Close" aria-label="Close search">
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+        >
+          <line x1="18" y1="6" x2="6" y2="18"></line>
+          <line x1="6" y1="6" x2="18" y2="18"></line>
+        </svg>
+      </button>
+    </div>
+  </div>
+
+  <!-- Results -->
+  <div class="results-container">
+    {#if isLoading}
+      <div class="loading">
+        <span class="loading-spinner"></span>
+        Loading search results...
+      </div>
+    {:else if expandedResults.length === 0}
+      <div class="no-results">No matching notes found</div>
+    {:else}
+      <div class="results-list">
+        {#each expandedResults as result (result.note.id)}
+          <div class="note-section">
+            <!-- Note header row -->
+            <button
+              class="note-row"
+              onclick={() => toggleNote(result.note.id)}
+              aria-expanded={expandedNotes.has(result.note.id)}
+            >
+              <span
+                class="disclosure-arrow"
+                class:expanded={expandedNotes.has(result.note.id)}
+              >
+                <svg
+                  width="12"
+                  height="12"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <polyline points="9 18 15 12 9 6"></polyline>
+                </svg>
+              </span>
+              <span class="note-icon">{getNoteIcon(result.note)}</span>
+              <span
+                class="note-title"
+                role="link"
+                onclick={(e) => {
+                  e.stopPropagation();
+                  handleNoteClick(result.note);
+                }}
+                onkeydown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.stopPropagation();
+                    handleNoteClick(result.note);
+                  }
+                }}
+                tabindex="0"
+              >
+                {result.note.title || 'Untitled'}
+              </span>
+              <span class="row-spacer"></span>
+              <span class="match-count"
+                >{getMatchCount(result)} match{getMatchCount(result) !== 1
+                  ? 'es'
+                  : ''}</span
+              >
+            </button>
+
+            <!-- Expanded matches -->
+            {#if expandedNotes.has(result.note.id)}
+              <div class="matches-list">
+                {#each result.contentMatches as match, idx (idx)}
+                  <div class="match-line">
+                    <span class="line-gutter">|</span>
+                    <SearchMatchEditor
+                      noteId={result.note.id}
+                      lineNumber={match.lineNumber}
+                      searchQuery={activeQuery}
+                      onWikilinkClick={handleWikilinkClick}
+                    />
+                  </div>
+                {/each}
+                {#if result.contentMatches.length === 0 && result.titleMatches.length > 0}
+                  <div class="match-line title-match">
+                    <span class="line-gutter">|</span>
+                    <span class="match-context muted">Title match</span>
+                  </div>
+                {/if}
+              </div>
+            {/if}
+          </div>
+        {/each}
+      </div>
+    {/if}
+  </div>
+</div>
+
+<style>
+  .expanded-search-view {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  /* Header */
+  .search-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1rem 1.5rem;
+    border-bottom: 1px solid var(--border-light);
+    flex-shrink: 0;
+  }
+
+  .header-left {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex: 1;
+    min-width: 0;
+  }
+
+  .search-input-wrapper {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex: 1;
+    min-width: 0;
+    max-width: 400px;
+    padding: 0.375rem 0.75rem;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border-light);
+    border-radius: 6px;
+    transition: border-color 0.15s ease;
+  }
+
+  .search-input-wrapper:focus-within {
+    border-color: var(--accent-primary);
+  }
+
+  .search-icon {
+    flex-shrink: 0;
+    color: var(--text-muted);
+  }
+
+  .search-input {
+    flex: 1;
+    min-width: 0;
+    border: none;
+    background: none;
+    font-size: 1rem;
+    font-weight: 500;
+    color: var(--text-primary);
+    outline: none;
+  }
+
+  .search-input::placeholder {
+    color: var(--text-muted);
+    font-weight: 400;
+  }
+
+  .result-count {
+    flex-shrink: 0;
+    font-size: 0.875rem;
+    color: var(--text-muted);
+  }
+
+  .header-controls {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+  .control-btn {
+    width: 28px;
+    height: 28px;
+    padding: 0;
+    border: none;
+    background: none;
+    color: var(--text-muted);
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 4px;
+    transition:
+      color 0.15s ease,
+      background 0.15s ease;
+  }
+
+  .control-btn:hover {
+    color: var(--text-secondary);
+    background: var(--bg-hover);
+  }
+
+  .control-btn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+
+  .control-btn:disabled:hover {
+    color: var(--text-muted);
+    background: none;
+  }
+
+  .save-btn:hover:not(:disabled) {
+    color: var(--accent-primary);
+  }
+
+  .saved-indicator {
+    width: 28px;
+    height: 28px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--accent-primary);
+  }
+
+  .close-btn {
+    width: 28px;
+    height: 28px;
+    margin-left: 8px;
+    padding: 0;
+    border: none;
+    background: none;
+    color: var(--text-muted);
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 4px;
+    transition:
+      color 0.15s ease,
+      background 0.15s ease;
+  }
+
+  .close-btn:hover {
+    color: var(--text-secondary);
+    background: var(--bg-hover);
+  }
+
+  /* Results container */
+  .results-container {
+    flex: 1;
+    overflow-y: auto;
+    padding: 0.5rem 0;
+  }
+
+  .loading {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    padding: 2rem;
+    color: var(--text-muted);
+  }
+
+  .loading-spinner {
+    width: 16px;
+    height: 16px;
+    border: 2px solid var(--border-light);
+    border-top-color: var(--accent-primary);
+    border-radius: 50%;
+    animation: spin 0.8s linear infinite;
+  }
+
+  @keyframes spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+
+  .no-results {
+    padding: 2rem;
+    text-align: center;
+    color: var(--text-muted);
+  }
+
+  /* Note section */
+  .note-section {
+    margin-top: 0.25rem;
+  }
+
+  .note-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 0.5rem 1rem;
+    width: 100%;
+    border: none;
+    background: none;
+    cursor: pointer;
+    text-align: left;
+    border-radius: 4px;
+    transition: background 0.15s ease;
+  }
+
+  .note-row:hover {
+    background: var(--bg-hover);
+  }
+
+  .disclosure-arrow {
+    flex-shrink: 0;
+    width: 20px;
+    height: 20px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-muted);
+    transition: transform 0.15s ease;
+  }
+
+  .disclosure-arrow.expanded {
+    transform: rotate(90deg);
+  }
+
+  .note-icon {
+    flex-shrink: 0;
+    font-size: 14px;
+    line-height: 1;
+  }
+
+  .note-title {
+    color: var(--text-primary);
+    font-size: 1rem;
+    font-weight: 500;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    cursor: pointer;
+  }
+
+  .note-title:hover {
+    text-decoration: underline;
+    color: var(--accent-primary);
+  }
+
+  .row-spacer {
+    flex: 1;
+  }
+
+  .match-count {
+    flex-shrink: 0;
+    font-size: 0.875rem;
+    color: var(--text-muted);
+  }
+
+  /* Matches list */
+  .matches-list {
+    padding: 0 1rem 0.5rem 2.75rem;
+  }
+
+  .match-line {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+    padding: 0.25rem 0;
+  }
+
+  .line-gutter {
+    flex-shrink: 0;
+    color: var(--text-muted);
+    font-size: 1rem;
+    line-height: 1.5;
+    user-select: none;
+    opacity: 0.5;
+  }
+
+  .match-context {
+    font-size: 0.875rem;
+    color: var(--text-secondary);
+    line-height: 1.5;
+    word-break: break-word;
+  }
+
+  .match-context.muted {
+    color: var(--text-muted);
+    font-style: italic;
+  }
+
+  .match-context :global(.search-highlight) {
+    background-color: var(--highlight-bg, #fef08a);
+    color: var(--highlight-text, #713f12);
+    padding: 0 0.125rem;
+    border-radius: 0.125rem;
+    font-weight: 500;
+  }
+
+  :global([data-theme='dark']) .match-context :global(.search-highlight) {
+    background-color: var(--highlight-bg-dark, #854d0e);
+    color: var(--highlight-text-dark, #fef9c3);
+  }
+</style>

--- a/src/renderer/src/components/LeftSidebar.svelte
+++ b/src/renderer/src/components/LeftSidebar.svelte
@@ -28,6 +28,7 @@
     activeSystemView:
       | 'settings'
       | 'search'
+      | 'expanded-search'
       | 'types'
       | 'daily'
       | 'review'
@@ -87,6 +88,11 @@
     isMobile = false,
     mobileDrawerOpen = false
   }: Props = $props();
+
+  // Detect platform for shortcut display
+  const isMacPlatform =
+    typeof navigator !== 'undefined' && /Mac|iPhone|iPod|iPad/.test(navigator.platform);
+  const modifierKey = isMacPlatform ? '⌘' : 'Ctrl';
 
   // Width state - track local width during resize
   let localWidth = $state<number | null>(null);
@@ -513,13 +519,16 @@
                 id="search-input"
                 type="text"
                 class="search-input"
-                placeholder="Search notes... (⌘O)"
+                placeholder="Search notes... ({modifierKey}O)"
                 value={searchQuery}
                 oninput={(e) => onSearchChange((e.target as HTMLInputElement).value)}
                 onfocus={onSearchFocus}
                 onblur={onSearchBlur}
                 onkeydown={onSearchKeyDown}
               />
+              {#if searchQuery.trim()}
+                <span class="shortcut-hint">{modifierKey}⇧↵ show all</span>
+              {/if}
             </div>
             {#if searchInputFocused && (searchQuery.trim() || searchResults.length > 0)}
               <div class="search-dropdown">
@@ -591,6 +600,9 @@
               onblur={onSearchBlur}
               onkeydown={onSearchKeyDown}
             />
+            {#if searchQuery.trim()}
+              <span class="shortcut-hint">{modifierKey}⇧↵ show all</span>
+            {/if}
           </div>
           {#if searchInputFocused && (searchQuery.trim() || searchResults.length > 0) && mobileSearchDropdownPosition}
             <!-- svelte-ignore a11y_no_static_element_interactions -->
@@ -1095,6 +1107,13 @@
 
   .search-input::placeholder {
     color: var(--text-muted);
+  }
+
+  .shortcut-hint {
+    flex-shrink: 0;
+    font-size: 0.6875rem;
+    color: var(--text-muted);
+    white-space: nowrap;
   }
 
   /* Prevent Safari auto-zoom on input focus */

--- a/src/renderer/src/components/QuickSearch.svelte
+++ b/src/renderer/src/components/QuickSearch.svelte
@@ -68,6 +68,16 @@
     if (event.key === 'Enter' && searchResults.length > 0) {
       onClose();
     }
+
+    // Close modal when opening expanded search view (Cmd+Shift+Enter)
+    if (
+      event.key === 'Enter' &&
+      (event.metaKey || event.ctrlKey) &&
+      event.shiftKey &&
+      searchQuery.trim()
+    ) {
+      onClose();
+    }
   }
 
   function handleOverlayClick(event: MouseEvent): void {
@@ -118,7 +128,11 @@
           oninput={(e) => onSearchChange((e.target as HTMLInputElement).value)}
           onkeydown={handleKeyDown}
         />
-        <div class="shortcut-hint">{modifierKey}O</div>
+        {#if searchQuery.trim()}
+          <div class="shortcut-hint">{modifierKey}⇧↵ show all</div>
+        {:else}
+          <div class="shortcut-hint">{modifierKey}O</div>
+        {/if}
       </div>
 
       {#if searchQuery.trim() || searchResults.length > 0}
@@ -153,6 +167,9 @@
             <span class="hint"><kbd>↑</kbd><kbd>↓</kbd> Navigate</span>
             <span class="hint"><kbd>Enter</kbd> Open</span>
             <span class="hint"><kbd>{modifierKey}</kbd><kbd>Enter</kbd> Add to Shelf</span
+            >
+            <span class="hint"
+              ><kbd>{modifierKey}</kbd><kbd>Shift</kbd><kbd>Enter</kbd> Expanded View</span
             >
             <span class="hint"><kbd>Esc</kbd> Close</span>
           </div>

--- a/src/renderer/src/components/SearchMatchEditor.svelte
+++ b/src/renderer/src/components/SearchMatchEditor.svelte
@@ -1,0 +1,342 @@
+<script lang="ts">
+  /**
+   * Single-line CodeMirror editor for search match context
+   * Similar to BacklinkLineEditor but loads the full line from the note
+   * and syncs changes back via Automerge. Highlights search matches.
+   */
+  import { onMount } from 'svelte';
+  import { EditorView, minimalSetup } from 'codemirror';
+  import {
+    EditorState,
+    StateEffect,
+    StateField,
+    type Extension,
+    type Range
+  } from '@codemirror/state';
+  import { keymap, Decoration, type DecorationSet } from '@codemirror/view';
+  import { defaultKeymap, history, historyKeymap } from '@codemirror/commands';
+  import { markdown } from '@codemirror/lang-markdown';
+  import { githubLight } from '@fsegurai/codemirror-theme-github-light';
+  import { githubDark } from '@fsegurai/codemirror-theme-github-dark';
+  import {
+    getNoteContent,
+    getNoteContentHandle,
+    automergeWikilinksExtension,
+    type WikilinkClickHandler
+  } from '../lib/automerge';
+
+  interface Props {
+    noteId: string;
+    /** 1-indexed line number from SearchMatch */
+    lineNumber: number;
+    /** Search query to highlight */
+    searchQuery?: string;
+    onWikilinkClick?: WikilinkClickHandler;
+  }
+
+  let { noteId, lineNumber, searchQuery, onWikilinkClick }: Props = $props();
+
+  let editorContainer: HTMLElement | null = $state(null);
+  let editorView: EditorView | null = null;
+  let isDarkMode = $state(false);
+  let mediaQuery: MediaQueryList | null = null;
+  let lineText = $state<string | null>(null);
+  let isLoading = $state(true);
+
+  // Track if we're currently syncing to avoid feedback loops
+  let isSyncing = false;
+
+  // Load the full line content from the note
+  async function loadLineContent(): Promise<void> {
+    isLoading = true;
+    try {
+      const content = await getNoteContent(noteId);
+      if (content) {
+        const lines = content.split('\n');
+        // lineNumber is 1-indexed, convert to 0-indexed
+        const zeroIndexedLine = lineNumber - 1;
+        if (zeroIndexedLine >= 0 && zeroIndexedLine < lines.length) {
+          lineText = lines[zeroIndexedLine];
+        } else {
+          lineText = '';
+        }
+      } else {
+        lineText = '';
+      }
+    } catch {
+      lineText = '';
+    }
+    isLoading = false;
+  }
+
+  // Theme for single-line editor
+  function getEditorTheme(): ReturnType<typeof EditorView.theme> {
+    return EditorView.theme({
+      '&': {
+        fontSize: '0.875rem',
+        fontFamily: 'var(--font-editor) !important',
+        lineHeight: '1.5',
+        backgroundColor: 'transparent'
+      },
+      '&.cm-editor': {
+        backgroundColor: 'transparent'
+      },
+      '&.cm-focused': {
+        outline: 'none',
+        boxShadow: 'none !important'
+      },
+      '.cm-content': {
+        fontFamily: 'var(--font-editor) !important',
+        padding: '0.125rem 0',
+        caretColor: 'var(--text-primary)'
+      },
+      '.cm-line': {
+        fontFamily: 'var(--font-editor) !important',
+        padding: '0'
+      },
+      '.cm-scroller': {
+        overflow: 'hidden !important'
+      },
+      '.cm-cursor': {
+        borderLeftColor: 'var(--text-primary)'
+      },
+      // Search highlight styling
+      '.cm-searchMatch': {
+        backgroundColor: 'var(--highlight-bg, #fef08a)',
+        color: 'var(--highlight-text, #713f12)',
+        padding: '0 1px',
+        borderRadius: '2px'
+      }
+    });
+  }
+
+  // Dark mode theme override for search highlights
+  const darkSearchHighlightTheme = EditorView.theme(
+    {
+      '.cm-searchMatch': {
+        backgroundColor: 'var(--highlight-bg-dark, #854d0e)',
+        color: 'var(--highlight-text-dark, #fef9c3)'
+      }
+    },
+    { dark: true }
+  );
+
+  /**
+   * Create a StateField that highlights search matches in the document.
+   * Splits multi-word queries and highlights each word separately.
+   */
+  function createSearchHighlightExtension(query: string): Extension {
+    if (!query.trim()) return [];
+
+    const searchMark = Decoration.mark({ class: 'cm-searchMatch' });
+
+    // Split query into words and escape each one
+    const words = query
+      .trim()
+      .split(/\s+/)
+      .filter((w) => w.length > 0);
+    if (words.length === 0) return [];
+
+    // Escape special regex characters for each word
+    const escapedWords = words.map((w) => w.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+    // Create alternation pattern: word1|word2|word3
+    const pattern = escapedWords.join('|');
+    const searchRegex = new RegExp(pattern, 'gi');
+
+    const searchHighlightField = StateField.define<DecorationSet>({
+      create(state) {
+        const decorations: Range<Decoration>[] = [];
+        const text = state.doc.toString();
+        let match;
+        while ((match = searchRegex.exec(text)) !== null) {
+          decorations.push(searchMark.range(match.index, match.index + match[0].length));
+        }
+        return Decoration.set(decorations);
+      },
+      update(decorations, tr) {
+        if (!tr.docChanged) return decorations;
+        // Rebuild decorations when document changes
+        const newDecorations: Range<Decoration>[] = [];
+        const text = tr.state.doc.toString();
+        let match;
+        // Reset regex lastIndex
+        searchRegex.lastIndex = 0;
+        while ((match = searchRegex.exec(text)) !== null) {
+          newDecorations.push(
+            searchMark.range(match.index, match.index + match[0].length)
+          );
+        }
+        return Decoration.set(newDecorations);
+      },
+      provide: (f) => EditorView.decorations.from(f)
+    });
+
+    return searchHighlightField;
+  }
+
+  function getExtensions(): Extension[] {
+    const extensions: Extension[] = [
+      minimalSetup,
+      history(),
+      keymap.of([...defaultKeymap, ...historyKeymap]),
+      markdown(),
+      EditorView.lineWrapping,
+      isDarkMode ? githubDark : githubLight,
+      getEditorTheme(),
+      EditorView.contentAttributes.of({ spellcheck: 'true' })
+    ];
+
+    // Add dark mode theme override for search highlights
+    if (isDarkMode) {
+      extensions.push(darkSearchHighlightTheme);
+    }
+
+    // Add search highlighting if query provided
+    if (searchQuery) {
+      extensions.push(createSearchHighlightExtension(searchQuery));
+    }
+
+    // Add wikilinks if handler provided
+    if (onWikilinkClick) {
+      extensions.push(automergeWikilinksExtension(onWikilinkClick));
+    }
+
+    // Add update listener for syncing changes to source note
+    extensions.push(
+      EditorView.updateListener.of((update) => {
+        if (update.docChanged && !isSyncing) {
+          syncToSource(update.state.doc.toString());
+        }
+      })
+    );
+
+    return extensions;
+  }
+
+  async function syncToSource(newLineText: string): Promise<void> {
+    isSyncing = true;
+    try {
+      const handle = await getNoteContentHandle(noteId);
+      if (!handle) return;
+
+      const doc = handle.doc();
+      if (!doc) return;
+
+      const content = doc.content || '';
+      const lines = content.split('\n');
+
+      // lineNumber is 1-indexed, convert to 0-indexed
+      const zeroIndexedLine = lineNumber - 1;
+
+      // Make sure line number is still valid
+      if (zeroIndexedLine < 0 || zeroIndexedLine >= lines.length) return;
+
+      // Replace the line
+      lines[zeroIndexedLine] = newLineText;
+      const newContent = lines.join('\n');
+
+      handle.change((d) => {
+        d.content = newContent;
+      });
+    } finally {
+      isSyncing = false;
+    }
+  }
+
+  function handleThemeChange(e: MediaQueryListEvent): void {
+    isDarkMode = e.matches;
+    if (editorView) {
+      editorView.dispatch({
+        effects: StateEffect.reconfigure.of(getExtensions())
+      });
+    }
+  }
+
+  function createEditor(): void {
+    if (!editorContainer || editorView || lineText === null) return;
+
+    const startState = EditorState.create({
+      doc: lineText,
+      extensions: getExtensions()
+    });
+
+    editorView = new EditorView({
+      state: startState,
+      parent: editorContainer
+    });
+  }
+
+  onMount(() => {
+    // Initialize theme detection
+    if (typeof window !== 'undefined') {
+      mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+      isDarkMode = mediaQuery.matches;
+      mediaQuery.addEventListener('change', handleThemeChange);
+    }
+
+    // Load the line content
+    loadLineContent();
+
+    return () => {
+      if (editorView) {
+        editorView.destroy();
+        editorView = null;
+      }
+      if (mediaQuery) {
+        mediaQuery.removeEventListener('change', handleThemeChange);
+      }
+    };
+  });
+
+  // Create editor when container is available and content is loaded
+  $effect(() => {
+    if (editorContainer && !editorView && lineText !== null) {
+      createEditor();
+    }
+  });
+
+  // Update editor content when lineText changes externally
+  $effect(() => {
+    if (editorView && lineText !== null && !isSyncing) {
+      const currentText = editorView.state.doc.toString();
+      if (currentText !== lineText) {
+        isSyncing = true;
+        editorView.dispatch({
+          changes: {
+            from: 0,
+            to: currentText.length,
+            insert: lineText
+          }
+        });
+        isSyncing = false;
+      }
+    }
+  });
+</script>
+
+{#if isLoading}
+  <span class="loading-text">Loading...</span>
+{:else}
+  <div class="search-match-editor editor-font" bind:this={editorContainer}></div>
+{/if}
+
+<style>
+  .search-match-editor {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .search-match-editor :global(.cm-editor) {
+    background: transparent;
+  }
+
+  .search-match-editor :global(.cm-gutters) {
+    display: none;
+  }
+
+  .loading-text {
+    color: var(--text-muted);
+    font-size: 0.875rem;
+    font-style: italic;
+  }
+</style>

--- a/src/renderer/src/components/SystemViews.svelte
+++ b/src/renderer/src/components/SystemViews.svelte
@@ -14,6 +14,7 @@
     activeSystemView:
       | 'settings'
       | 'search'
+      | 'expanded-search'
       | 'types'
       | 'daily'
       | 'review'

--- a/src/renderer/src/lib/automerge/index.ts
+++ b/src/renderer/src/lib/automerge/index.ts
@@ -73,7 +73,9 @@ export type {
   NoteFilter,
   NoteFilterInput,
   // Source format type
-  SourceFormat
+  SourceFormat,
+  // Saved search type
+  SavedSearch
 } from './types';
 
 // State management
@@ -228,6 +230,16 @@ export {
   unarchiveConversation,
   deleteConversation,
   bumpItemToRecent,
+
+  // Saved search getters
+  getSavedSearches,
+  getSavedSearch,
+
+  // Saved search mutations
+  createSavedSearch,
+  updateSavedSearch,
+  archiveSavedSearch,
+  deleteSavedSearch,
 
   // Shelf items (persisted in Automerge)
   getShelfItems,
@@ -422,6 +434,7 @@ export {
   generateRoutineId,
   generateRoutineCompletionId,
   generateRoutineMaterialId,
+  generateSavedSearchId,
   nowISO
 } from './utils';
 

--- a/src/renderer/src/lib/automerge/types.ts
+++ b/src/renderer/src/lib/automerge/types.ts
@@ -10,7 +10,7 @@
  * Types of items that can appear in the sidebar
  * Extensible for future types: 'epub' | 'pdf' | 'bookmark'
  */
-export type SidebarItemType = 'note' | 'conversation';
+export type SidebarItemType = 'note' | 'conversation' | 'saved-search';
 
 /**
  * Reference to a sidebar item stored in workspace arrays
@@ -43,6 +43,7 @@ export interface SidebarItem {
 export type ActiveItem =
   | { type: 'note'; id: string }
   | { type: 'conversation'; id: string }
+  | { type: 'saved-search'; id: string }
   | null;
 
 /**
@@ -51,6 +52,7 @@ export type ActiveItem =
 export type SystemView =
   | 'settings'
   | 'search'
+  | 'expanded-search'
   | 'types'
   | 'daily'
   | 'review'
@@ -567,6 +569,30 @@ export interface NotesDocument {
   processedNoteIds?: Record<string, string>;
   /** Mapping of noteId -> Automerge URL for content documents */
   contentUrls?: Record<string, string>;
+  /** Saved searches keyed by ID */
+  savedSearches?: Record<string, SavedSearch>;
+}
+
+// ============================================================================
+// Saved Search Types
+// ============================================================================
+
+/**
+ * A saved search that can be displayed in the sidebar and linked to via wikilinks
+ */
+export interface SavedSearch {
+  /** Unique ID with format "search-xxxxxxxx" */
+  id: string;
+  /** User-defined title for the search */
+  title: string;
+  /** The search query text */
+  query: string;
+  /** ISO timestamp when created */
+  created: string;
+  /** ISO timestamp when last updated */
+  updated: string;
+  /** Soft delete flag */
+  archived?: boolean;
 }
 
 /**

--- a/src/renderer/src/lib/automerge/utils.ts
+++ b/src/renderer/src/lib/automerge/utils.ts
@@ -123,6 +123,14 @@ export function generateConversationId(): string {
 }
 
 /**
+ * Generate a saved search ID
+ * Format: "search-xxxxxxxx"
+ */
+export function generateSavedSearchId(): string {
+  return generateId('search');
+}
+
+/**
  * Generate a message ID
  * Format: "msg-xxxxxxxx"
  */


### PR DESCRIPTION
Adds SavedSearch as a first-class entity that can be displayed in the sidebar alongside notes, linked via wikilinks, pinned, and moved between workspaces. When a saved search query is edited, its title automatically updates. The search index is tracked reactively to ensure content matches load correctly after index building completes on app restart.

- **Type definitions**: Added SavedSearch type, extended SidebarItemType and ActiveItem
- **State management**: Full CRUD functions for saved searches with Automerge persistence
- **Sidebar integration**: Saved searches display with 🔍 icon and support context menu actions
- **Wikilink support**: Saved searches can be referenced via [[search-id]] syntax
- **UI fixes**: Fixed effect dependencies to prevent unintended re-renders and re-syncing of search index state

🤖 Generated with [Claude Code](https://claude.com/claude-code)