### PR TITLE
Simplify search UI and add saved searches to shelf

### DIFF
--- a/src/renderer/src/components/ExpandedSearchView.svelte
+++ b/src/renderer/src/components/ExpandedSearchView.svelte
@@ -166,16 +166,6 @@
     }
   }
 
-  function expandAll(): void {
-    for (const result of expandedResults) {
-      expandedNotes.add(result.note.id);
-    }
-  }
-
-  function collapseAll(): void {
-    expandedNotes.clear();
-  }
-
   function handleNoteClick(note: NoteMetadata): void {
     onSelect(note);
   }
@@ -240,10 +230,11 @@
           >
             <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"></path>
           </svg>
+          <span>Saved</span>
         </span>
       {:else}
         <button
-          class="control-btn save-btn"
+          class="save-btn"
           onclick={handleSaveSearch}
           title="Save search"
           aria-label="Save search"
@@ -261,61 +252,9 @@
           >
             <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"></path>
           </svg>
+          <span>Save Search</span>
         </button>
       {/if}
-      <button
-        class="control-btn"
-        onclick={expandAll}
-        title="Expand all"
-        aria-label="Expand all"
-      >
-        <svg
-          width="14"
-          height="14"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="2"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-        >
-          <polyline points="7 13 12 18 17 13"></polyline>
-          <polyline points="7 6 12 11 17 6"></polyline>
-        </svg>
-      </button>
-      <button
-        class="control-btn"
-        onclick={collapseAll}
-        title="Collapse all"
-        aria-label="Collapse all"
-      >
-        <svg
-          width="14"
-          height="14"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="2"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-        >
-          <polyline points="17 11 12 6 7 11"></polyline>
-          <polyline points="17 18 12 13 7 18"></polyline>
-        </svg>
-      </button>
-      <button class="close-btn" onclick={onClose} title="Close" aria-label="Close search">
-        <svg
-          width="16"
-          height="16"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="2"
-        >
-          <line x1="18" y1="6" x2="6" y2="18"></line>
-          <line x1="6" y1="6" x2="18" y2="18"></line>
-        </svg>
-      </button>
     </div>
   </div>
 
@@ -423,8 +362,7 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 1rem 1.5rem;
-    border-bottom: 1px solid var(--border-light);
+    padding: 1rem;
     flex-shrink: 0;
   }
 
@@ -487,72 +425,39 @@
     gap: 4px;
   }
 
-  .control-btn {
-    width: 28px;
-    height: 28px;
-    padding: 0;
+  .save-btn {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 0 6px 12px;
     border: none;
     background: none;
     color: var(--text-muted);
     cursor: pointer;
-    display: flex;
-    align-items: center;
-    justify-content: center;
     border-radius: 4px;
+    font-size: 0.875rem;
     transition:
       color 0.15s ease,
       background 0.15s ease;
-  }
-
-  .control-btn:hover {
-    color: var(--text-secondary);
-    background: var(--bg-hover);
-  }
-
-  .control-btn:disabled {
-    opacity: 0.4;
-    cursor: not-allowed;
-  }
-
-  .control-btn:disabled:hover {
-    color: var(--text-muted);
-    background: none;
   }
 
   .save-btn:hover:not(:disabled) {
     color: var(--accent-primary);
+    background: var(--bg-hover);
+  }
+
+  .save-btn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
   }
 
   .saved-indicator {
-    width: 28px;
-    height: 28px;
     display: flex;
     align-items: center;
-    justify-content: center;
+    gap: 6px;
+    padding: 6px 0 6px 12px;
     color: var(--accent-primary);
-  }
-
-  .close-btn {
-    width: 28px;
-    height: 28px;
-    margin-left: 8px;
-    padding: 0;
-    border: none;
-    background: none;
-    color: var(--text-muted);
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    border-radius: 4px;
-    transition:
-      color 0.15s ease,
-      background 0.15s ease;
-  }
-
-  .close-btn:hover {
-    color: var(--text-secondary);
-    background: var(--bg-hover);
+    font-size: 0.875rem;
   }
 
   /* Results container */

--- a/src/renderer/src/components/MainView.svelte
+++ b/src/renderer/src/components/MainView.svelte
@@ -220,16 +220,21 @@
   function handleAddToShelf(): void {
     if (
       activeItem &&
-      (activeItem.type === 'note' || activeItem.type === 'conversation')
+      (activeItem.type === 'note' ||
+        activeItem.type === 'conversation' ||
+        activeItem.type === 'saved-search')
     ) {
       automergeShelfStore.addItem(activeItem.type, activeItem.id);
       openShelfPanel();
     }
   }
 
-  // Check if current item is on shelf (only notes and conversations can be on shelf)
+  // Check if current item is on shelf
   const isOnShelf = $derived(
-    activeItem && (activeItem.type === 'note' || activeItem.type === 'conversation')
+    activeItem &&
+      (activeItem.type === 'note' ||
+        activeItem.type === 'conversation' ||
+        activeItem.type === 'saved-search')
       ? automergeShelfStore.isOnShelf(activeItem.type, activeItem.id)
       : false
   );

--- a/src/renderer/src/components/ShelfPanel.svelte
+++ b/src/renderer/src/components/ShelfPanel.svelte
@@ -19,7 +19,7 @@
     /** Toggle expand/collapse callback */
     onToggleExpand?: () => void;
     /** Navigate to item callback */
-    onNavigate?: (type: 'note' | 'conversation', id: string) => void;
+    onNavigate?: (type: 'note' | 'conversation' | 'saved-search', id: string) => void;
     /** Switch to chat panel callback (only used in expanded mode) */
     onSwitchToChat?: () => void;
   }

--- a/src/renderer/src/components/SidebarItems.svelte
+++ b/src/renderer/src/components/SidebarItems.svelte
@@ -881,10 +881,14 @@
     return false;
   });
 
-  // Check if the context menu item is on the shelf (only notes and conversations can be on shelf)
+  // Check if the context menu item is on the shelf
   const contextMenuItemOnShelf = $derived.by(() => {
     if (!contextMenuItemId || !contextMenuItemType) return false;
-    if (contextMenuItemType !== 'note' && contextMenuItemType !== 'conversation')
+    if (
+      contextMenuItemType !== 'note' &&
+      contextMenuItemType !== 'conversation' &&
+      contextMenuItemType !== 'saved-search'
+    )
       return false;
     return isItemOnShelf(contextMenuItemType, contextMenuItemId);
   });
@@ -898,8 +902,13 @@
 
   function handleToggleShelf(): void {
     if (!contextMenuItemId || !contextMenuItemType) return;
-    // Only notes and conversations can be on shelf
-    if (contextMenuItemType !== 'note' && contextMenuItemType !== 'conversation') return;
+    // Only notes, conversations, and saved searches can be on shelf
+    if (
+      contextMenuItemType !== 'note' &&
+      contextMenuItemType !== 'conversation' &&
+      contextMenuItemType !== 'saved-search'
+    )
+      return;
     if (contextMenuItemOnShelf) {
       removeShelfItem(contextMenuItemType, contextMenuItemId);
     } else {
@@ -1124,6 +1133,16 @@
 
 <!-- Context menu -->
 {#if contextMenuOpen}
+  <!-- Backdrop to catch clicks outside menu -->
+  <div
+    class="context-menu-backdrop"
+    onclick={closeContextMenu}
+    oncontextmenu={(e) => {
+      e.preventDefault();
+      closeContextMenu();
+    }}
+    role="presentation"
+  ></div>
   <div
     bind:this={contextMenuElement}
     class="context-menu"
@@ -1153,8 +1172,8 @@
       >
     </button>
 
-    <!-- Shelf toggle (only for notes and conversations) -->
-    {#if contextMenuItemType === 'note' || contextMenuItemType === 'conversation'}
+    <!-- Shelf toggle (for notes, conversations, and saved searches) -->
+    {#if contextMenuItemType === 'note' || contextMenuItemType === 'conversation' || contextMenuItemType === 'saved-search'}
       <button class="context-menu-item" onclick={handleToggleShelf} role="menuitem">
         <svg
           width="14"
@@ -1570,6 +1589,13 @@
   }
 
   /* Context menu styles */
+  .context-menu-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 999;
+    -webkit-app-region: no-drag;
+  }
+
   .context-menu {
     position: fixed;
     z-index: 1000;

--- a/src/renderer/src/lib/automerge/shelf-state.svelte.ts
+++ b/src/renderer/src/lib/automerge/shelf-state.svelte.ts
@@ -50,35 +50,39 @@ class ShelfStore {
   /**
    * Check if an item is on the shelf
    */
-  isOnShelf(type: 'note' | 'conversation', id: string): boolean {
+  isOnShelf(type: 'note' | 'conversation' | 'saved-search', id: string): boolean {
     return isItemOnShelf(type, id);
   }
 
   /**
    * Add an item to the shelf
    */
-  addItem(type: 'note' | 'conversation', id: string): void {
+  addItem(type: 'note' | 'conversation' | 'saved-search', id: string): void {
     addShelfItem(type, id);
   }
 
   /**
    * Remove an item from the shelf
    */
-  removeItem(type: 'note' | 'conversation', id: string): void {
+  removeItem(type: 'note' | 'conversation' | 'saved-search', id: string): void {
     removeShelfItem(type, id);
   }
 
   /**
    * Toggle the expanded state of an item
    */
-  toggleExpanded(type: 'note' | 'conversation', id: string): void {
+  toggleExpanded(type: 'note' | 'conversation' | 'saved-search', id: string): void {
     toggleShelfItemExpanded(type, id);
   }
 
   /**
    * Set the expanded state of an item
    */
-  setExpanded(type: 'note' | 'conversation', id: string, expanded: boolean): void {
+  setExpanded(
+    type: 'note' | 'conversation' | 'saved-search',
+    id: string,
+    expanded: boolean
+  ): void {
     setShelfItemExpanded(type, id, expanded);
   }
 

--- a/src/renderer/src/lib/automerge/state.svelte.ts
+++ b/src/renderer/src/lib/automerge/state.svelte.ts
@@ -3527,7 +3527,10 @@ export function getShelfItems(): ShelfItemData[] {
 /**
  * Check if an item is on the shelf
  */
-export function isItemOnShelf(type: 'note' | 'conversation', id: string): boolean {
+export function isItemOnShelf(
+  type: 'note' | 'conversation' | 'saved-search',
+  id: string
+): boolean {
   const items = currentDoc.shelfItems ?? [];
   return items.some((item) => item.type === type && item.id === id);
 }
@@ -3535,7 +3538,10 @@ export function isItemOnShelf(type: 'note' | 'conversation', id: string): boolea
 /**
  * Add an item to the shelf
  */
-export function addShelfItem(type: 'note' | 'conversation', id: string): void {
+export function addShelfItem(
+  type: 'note' | 'conversation' | 'saved-search',
+  id: string
+): void {
   if (!docHandle) throw new Error('Not initialized');
 
   // Don't add if already on shelf
@@ -3552,7 +3558,10 @@ export function addShelfItem(type: 'note' | 'conversation', id: string): void {
 /**
  * Remove an item from the shelf
  */
-export function removeShelfItem(type: 'note' | 'conversation', id: string): void {
+export function removeShelfItem(
+  type: 'note' | 'conversation' | 'saved-search',
+  id: string
+): void {
   if (!docHandle) throw new Error('Not initialized');
 
   docHandle.change((doc) => {
@@ -3569,7 +3578,10 @@ export function removeShelfItem(type: 'note' | 'conversation', id: string): void
 /**
  * Toggle the expanded state of a shelf item
  */
-export function toggleShelfItemExpanded(type: 'note' | 'conversation', id: string): void {
+export function toggleShelfItemExpanded(
+  type: 'note' | 'conversation' | 'saved-search',
+  id: string
+): void {
   if (!docHandle) throw new Error('Not initialized');
 
   docHandle.change((doc) => {
@@ -3585,7 +3597,7 @@ export function toggleShelfItemExpanded(type: 'note' | 'conversation', id: strin
  * Set the expanded state of a shelf item
  */
 export function setShelfItemExpanded(
-  type: 'note' | 'conversation',
+  type: 'note' | 'conversation' | 'saved-search',
   id: string,
   expanded: boolean
 ): void {

--- a/src/renderer/src/lib/automerge/types.ts
+++ b/src/renderer/src/lib/automerge/types.ts
@@ -599,7 +599,7 @@ export interface SavedSearch {
  * Shelf item stored in Automerge document
  */
 export interface ShelfItemData {
-  type: 'note' | 'conversation';
+  type: 'note' | 'conversation' | 'saved-search';
   id: string;
   isExpanded: boolean;
 }


### PR DESCRIPTION
## Summary

- Simplify expanded search header by removing expand all, collapse all, and close buttons; enhance save button with "Save Search" text
- Update search header styling to remove border separator and align controls with results content  
- Add saved searches as first-class shelf items so users can save searches, add them to shelf, and view results in the shelf panel
- Enable add-to-shelf for saved searches via toolbar, keyboard shortcuts, and context menu
- Improve context menu by adding transparent backdrop to close menu when clicking outside

## Test plan

- Open a search and verify the simplified header with just the save button
- Save a search and verify it shows the "Saved" indicator
- Add a saved search to the shelf via the toolbar or context menu
- Verify the shelf item displays the full search interface with results
- Right-click on a saved search in the sidebar and verify shelf options work
- Click outside the context menu and verify it closes