### PR TITLE
Fix gutter plus button position with embedded images

### DIFF
--- a/src/renderer/src/lib/automerge/gutter-plus-button.svelte.ts
+++ b/src/renderer/src/lib/automerge/gutter-plus-button.svelte.ts
@@ -240,18 +240,17 @@ export function gutterPlusButtonExtension(onShowMenu: GutterMenuHandler): Extens
         // Get the line at the mouse position
         let lineNumber: number | null = null;
 
-        // First try direct position lookup
-        let pos = view.posAtCoords({ x: event.clientX, y: event.clientY });
+        // Convert screen Y to document-relative height
+        // documentTop is the top of the document content relative to the viewport
+        const docHeight = event.clientY - view.documentTop;
 
-        // If that fails (mouse in gutter/empty space), try using a point inside the content area
-        if (pos === null) {
-          const contentRect = view.contentDOM.getBoundingClientRect();
-          // Use a point just inside the content area at the same Y level
-          pos = view.posAtCoords({ x: contentRect.left + 1, y: event.clientY });
-        }
+        // Use lineBlockAtHeight which correctly handles block widgets (images, decks)
+        // This maps visual height to the line block at that position
+        const lineBlock = view.lineBlockAtHeight(docHeight);
 
-        if (pos !== null) {
-          lineNumber = view.state.doc.lineAt(pos).number;
+        if (lineBlock) {
+          // Get the line number from the line block's document position
+          lineNumber = view.state.doc.lineAt(lineBlock.from).number;
         }
 
         if (lineNumber !== null) {

--- a/src/renderer/src/lib/automerge/image-extension.svelte.ts
+++ b/src/renderer/src/lib/automerge/image-extension.svelte.ts
@@ -235,6 +235,16 @@ class ImageWidget extends WidgetType {
       img.className = 'cm-inline-image';
       img.draggable = false;
 
+      // Request height remeasurement when image loads
+      // This ensures CodeMirror's block height tracking stays accurate
+      img.onload = () => {
+        try {
+          this.view.requestMeasure();
+        } catch {
+          // View may have been destroyed
+        }
+      };
+
       // Handle load errors
       img.onerror = () => {
         img.style.display = 'none';
@@ -242,6 +252,12 @@ class ImageWidget extends WidgetType {
         errorEl.className = 'cm-image-error-text';
         errorEl.textContent = '[Image failed to load]';
         container.appendChild(errorEl);
+        // Also request remeasurement on error
+        try {
+          this.view.requestMeasure();
+        } catch {
+          // View may have been destroyed
+        }
       };
 
       container.appendChild(img);
@@ -518,7 +534,10 @@ function createImageDomEventHandlers(): Extension {
 const imageStyles = EditorView.baseTheme({
   '.cm-image-widget': {
     display: 'block',
-    margin: '8px 0'
+    // Use padding instead of margin so CodeMirror's height measurement includes
+    // the spacing. Margins are not included in offsetHeight/getBoundingClientRect,
+    // which causes block height tracking and gutter positioning to be off.
+    padding: '8px 0'
   },
   '.cm-inline-image': {
     maxWidth: '100%',


### PR DESCRIPTION
Fixes the gutter plus button appearing on the wrong line when images are embedded in notes.

The root cause was that image widgets used CSS margins (excluded from height measurements) instead of padding. This caused CodeMirror's block height tracking to be off by 16px, breaking gutter positioning for all lines below images.

Changes use padding instead, add requestMeasure() on image load for dynamic height updates, and switch hover detection to lineBlockAtHeight() which correctly handles block widgets like images and deck embeds.

🤖 Generated with Claude Code