### PR TITLE
Make media notes respect note type editorChips configuration

### DIFF
--- a/src/renderer/src/components/EpubViewer.svelte
+++ b/src/renderer/src/components/EpubViewer.svelte
@@ -20,6 +20,7 @@
   import EpubToc from './EpubToc.svelte';
   import EpubHighlights from './EpubHighlights.svelte';
   import NoteHeader from './NoteHeader.svelte';
+  import MediaChips from './MediaChips.svelte';
   import Tooltip from './Tooltip.svelte';
 
   // Props
@@ -315,47 +316,6 @@ ${highlightLines.join('\n\n')}
     return `${Math.round(value)}%`;
   }
 
-  // Format relative time for chips
-  function formatRelativeTime(dateString: string): string {
-    if (!dateString) return '—';
-    try {
-      const date = new Date(dateString);
-      if (isNaN(date.getTime())) return dateString;
-
-      const now = new Date();
-      const diffMs = now.getTime() - date.getTime();
-      const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
-
-      if (diffDays === 0) {
-        const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
-        if (diffHours === 0) {
-          const diffMins = Math.floor(diffMs / (1000 * 60));
-          if (diffMins <= 1) return 'just now';
-          return `${diffMins}m ago`;
-        }
-        return `${diffHours}h ago`;
-      } else if (diffDays === 1) {
-        return 'yesterday';
-      } else if (diffDays < 7) {
-        return `${diffDays}d ago`;
-      } else if (diffDays < 30) {
-        const weeks = Math.floor(diffDays / 7);
-        return `${weeks}w ago`;
-      } else if (diffDays < 365) {
-        const months = Math.floor(diffDays / 30);
-        return `${months}mo ago`;
-      } else {
-        return date.toLocaleDateString(undefined, {
-          month: 'short',
-          day: 'numeric',
-          year: '2-digit'
-        });
-      }
-    } catch {
-      return dateString;
-    }
-  }
-
   // Save final state on unmount
   function saveState(): void {
     if (readingStateDebounceTimer) {
@@ -419,35 +379,14 @@ ${highlightLines.join('\n\n')}
     <header class="epub-header">
       <NoteHeader {note} {onTitleChange}>
         {#snippet chips()}
-          <div class="epub-chips">
-            {#if epubProps().epubAuthor}
-              <div class="chip">
-                <span class="chip-label">author</span>
-                <span class="chip-divider"></span>
-                <span class="chip-value">{epubProps().epubAuthor}</span>
-              </div>
-            {/if}
-            <div class="chip">
-              <span class="chip-label">progress</span>
-              <span class="chip-divider"></span>
-              <span class="chip-value">{formatProgress(currentProgress)}</span>
-            </div>
-            {#if epubProps().lastRead}
-              <div class="chip">
-                <span class="chip-label">last read</span>
-                <span class="chip-divider"></span>
-                <span class="chip-value">{formatRelativeTime(epubProps().lastRead!)}</span
-                >
-              </div>
-            {/if}
-            {#if highlights.length > 0}
-              <div class="chip">
-                <span class="chip-label">highlights</span>
-                <span class="chip-divider"></span>
-                <span class="chip-value">{highlights.length}</span>
-              </div>
-            {/if}
-          </div>
+          <MediaChips
+            {note}
+            sourceFormat="epub"
+            computedValues={{
+              progress: formatProgress(currentProgress),
+              highlights: highlights.length > 0 ? highlights.length : undefined
+            }}
+          />
         {/snippet}
       </NoteHeader>
     </header>
@@ -777,48 +716,6 @@ ${highlightLines.join('\n\n')}
   .epub-header {
     padding: 0 1.5rem;
     flex-shrink: 0;
-  }
-
-  /* Property chips */
-  .epub-chips {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.375rem;
-    padding-left: 0.25rem;
-    margin-top: 0.25rem;
-    margin-bottom: 0.75rem;
-  }
-
-  .chip {
-    display: inline-flex;
-    align-items: stretch;
-    border: 1px solid var(--border-light);
-    border-radius: 9999px;
-    background: var(--bg-secondary);
-    font-size: 0.7rem;
-    white-space: nowrap;
-    overflow: hidden;
-  }
-
-  .chip-label {
-    display: flex;
-    align-items: center;
-    padding: 0.125rem 0.5rem 0.125rem 0.625rem;
-    color: var(--text-muted);
-    background: var(--bg-tertiary);
-    border-radius: 9999px 0 0 9999px;
-  }
-
-  .chip-divider {
-    width: 1px;
-    background: var(--border-light);
-  }
-
-  .chip-value {
-    display: flex;
-    align-items: center;
-    padding: 0.125rem 0.625rem 0.125rem 0.5rem;
-    color: var(--text-secondary);
   }
 
   /* Content area */

--- a/src/renderer/src/components/MediaChips.svelte
+++ b/src/renderer/src/components/MediaChips.svelte
@@ -1,0 +1,180 @@
+<script lang="ts">
+  /**
+   * Wrapper component for media note chips (EPUB, PDF, Webpage)
+   * Handles media-specific property definitions and computed values,
+   * while delegating to EditorChips for actual rendering.
+   */
+  import type { NoteMetadata, SourceFormat } from '../lib/automerge';
+  import {
+    getNoteType,
+    setNoteProp,
+    setActiveNoteId,
+    addNoteToWorkspace
+  } from '../lib/automerge';
+  import { getMediaProperties, getMediaDefaultChips } from '../lib/media-properties';
+  import EditorChips from './EditorChips.svelte';
+
+  interface Props {
+    note: NoteMetadata;
+    sourceFormat: SourceFormat;
+    /** Computed values from viewer state (progress, highlights count, pages, etc.) */
+    computedValues?: Record<string, unknown>;
+    /** Handler for navigating to linked notes */
+    onNoteClick?: (noteId: string) => void;
+    /** Handler for opening external links (for webpage source) */
+    onOpenExternal?: (url: string) => void;
+  }
+
+  let {
+    note,
+    sourceFormat,
+    computedValues = {},
+    onNoteClick,
+    onOpenExternal
+  }: Props = $props();
+
+  // Get the note type (user-configured type, not media format)
+  const noteType = $derived(getNoteType(note.type));
+
+  // Get media-specific property definitions
+  const mediaProperties = $derived(getMediaProperties(sourceFormat));
+
+  // Determine which chips to display:
+  // 1. If noteType.editorChips is defined and non-empty, use that
+  // 2. Otherwise, use media-specific defaults
+  const effectiveEditorChips = $derived.by(() => {
+    if (noteType?.editorChips?.length) {
+      return noteType.editorChips;
+    }
+    return getMediaDefaultChips(sourceFormat);
+  });
+
+  // Create effective note type with overridden editorChips
+  // Avoid spreading Automerge objects - create a plain object with only needed properties
+  const effectiveNoteType = $derived.by(() => {
+    if (!noteType) {
+      // No note type defined, create a minimal one with media defaults
+      return {
+        id: 'type-media',
+        name: 'Media',
+        purpose: '',
+        icon: '',
+        archived: false,
+        created: '',
+        editorChips: effectiveEditorChips,
+        properties: []
+      };
+    }
+    // Create a plain object to avoid Automerge proxy issues
+    return {
+      id: noteType.id,
+      name: noteType.name,
+      purpose: noteType.purpose,
+      icon: noteType.icon,
+      archived: noteType.archived,
+      created: noteType.created,
+      editorChips: effectiveEditorChips,
+      properties: noteType.properties,
+      agentInstructions: noteType.agentInstructions
+    };
+  });
+
+  // Handle property changes (for editable fields)
+  function handlePropChange(propName: string, value: unknown): void {
+    setNoteProp(note.id, propName, value);
+  }
+
+  // Handle note click navigation
+  function handleNoteClick(noteId: string): void {
+    if (onNoteClick) {
+      onNoteClick(noteId);
+    } else {
+      setActiveNoteId(noteId);
+      addNoteToWorkspace(noteId);
+    }
+  }
+</script>
+
+<div class="media-chips-wrapper">
+  <EditorChips
+    {note}
+    noteType={effectiveNoteType}
+    onPropChange={handlePropChange}
+    onNoteClick={handleNoteClick}
+    {computedValues}
+    additionalProperties={mediaProperties}
+  />
+  {#if sourceFormat === 'webpage' && computedValues.source}
+    <button
+      class="chip chip-link"
+      onclick={() => onOpenExternal?.(String(computedValues.source))}
+      type="button"
+    >
+      <span class="chip-label">source</span>
+      <span class="chip-divider"></span>
+      <span class="chip-value link-icon">
+        <svg
+          width="12"
+          height="12"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+        >
+          <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
+          <polyline points="15 3 21 3 21 9"></polyline>
+          <line x1="10" y1="14" x2="21" y2="3"></line>
+        </svg>
+      </span>
+    </button>
+  {/if}
+</div>
+
+<style>
+  .media-chips-wrapper {
+    display: contents;
+  }
+
+  .chip {
+    display: inline-flex;
+    align-items: stretch;
+    border: 1px solid var(--border-light);
+    border-radius: 9999px;
+    background: var(--bg-secondary);
+    font-size: 0.7rem;
+    white-space: nowrap;
+    overflow: hidden;
+    cursor: pointer;
+  }
+
+  .chip:hover {
+    background: var(--bg-tertiary);
+  }
+
+  .chip-label {
+    display: flex;
+    align-items: center;
+    padding: 0.125rem 0.5rem 0.125rem 0.625rem;
+    color: var(--text-muted);
+    background: var(--bg-tertiary);
+    border-radius: 9999px 0 0 9999px;
+  }
+
+  .chip-divider {
+    width: 1px;
+    background: var(--border-light);
+  }
+
+  .chip-value {
+    display: flex;
+    align-items: center;
+    padding: 0.125rem 0.625rem 0.125rem 0.5rem;
+    color: var(--text-secondary);
+  }
+
+  .link-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+</style>

--- a/src/renderer/src/components/PdfViewer.svelte
+++ b/src/renderer/src/components/PdfViewer.svelte
@@ -31,6 +31,7 @@
   import PdfOutline from './PdfOutline.svelte';
   import PdfHighlights from './PdfHighlights.svelte';
   import NoteHeader from './NoteHeader.svelte';
+  import MediaChips from './MediaChips.svelte';
   import Tooltip from './Tooltip.svelte';
 
   // Props
@@ -327,47 +328,6 @@ ${highlightLines.join('\n\n')}
     return `${Math.round((currentPage / totalPages) * 100)}%`;
   }
 
-  // Format relative time for chips
-  function formatRelativeTime(dateString: string): string {
-    if (!dateString) return '—';
-    try {
-      const date = new Date(dateString);
-      if (isNaN(date.getTime())) return dateString;
-
-      const now = new Date();
-      const diffMs = now.getTime() - date.getTime();
-      const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
-
-      if (diffDays === 0) {
-        const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
-        if (diffHours === 0) {
-          const diffMins = Math.floor(diffMs / (1000 * 60));
-          if (diffMins <= 1) return 'just now';
-          return `${diffMins}m ago`;
-        }
-        return `${diffHours}h ago`;
-      } else if (diffDays === 1) {
-        return 'yesterday';
-      } else if (diffDays < 7) {
-        return `${diffDays}d ago`;
-      } else if (diffDays < 30) {
-        const weeks = Math.floor(diffDays / 7);
-        return `${weeks}w ago`;
-      } else if (diffDays < 365) {
-        const months = Math.floor(diffDays / 30);
-        return `${months}mo ago`;
-      } else {
-        return date.toLocaleDateString(undefined, {
-          month: 'short',
-          day: 'numeric',
-          year: '2-digit'
-        });
-      }
-    } catch {
-      return dateString;
-    }
-  }
-
   // Save final state on unmount
   function saveState(): void {
     if (readingStateDebounceTimer) {
@@ -429,39 +389,15 @@ ${highlightLines.join('\n\n')}
     <header class="pdf-header">
       <NoteHeader {note} {onTitleChange}>
         {#snippet chips()}
-          <div class="pdf-chips">
-            {#if pdfProps().pdfAuthor}
-              <div class="chip">
-                <span class="chip-label">author</span>
-                <span class="chip-divider"></span>
-                <span class="chip-value">{pdfProps().pdfAuthor}</span>
-              </div>
-            {/if}
-            <div class="chip">
-              <span class="chip-label">pages</span>
-              <span class="chip-divider"></span>
-              <span class="chip-value">{currentPage} / {totalPages}</span>
-            </div>
-            <div class="chip">
-              <span class="chip-label">progress</span>
-              <span class="chip-divider"></span>
-              <span class="chip-value">{formatProgress()}</span>
-            </div>
-            {#if pdfProps().lastRead}
-              <div class="chip">
-                <span class="chip-label">last read</span>
-                <span class="chip-divider"></span>
-                <span class="chip-value">{formatRelativeTime(pdfProps().lastRead!)}</span>
-              </div>
-            {/if}
-            {#if highlights.length > 0}
-              <div class="chip">
-                <span class="chip-label">highlights</span>
-                <span class="chip-divider"></span>
-                <span class="chip-value">{highlights.length}</span>
-              </div>
-            {/if}
-          </div>
+          <MediaChips
+            {note}
+            sourceFormat="pdf"
+            computedValues={{
+              pages: `${currentPage} / ${totalPages}`,
+              progress: formatProgress(),
+              highlights: highlights.length > 0 ? highlights.length : undefined
+            }}
+          />
         {/snippet}
       </NoteHeader>
     </header>
@@ -788,48 +724,6 @@ ${highlightLines.join('\n\n')}
   .pdf-header {
     padding: 0 1.5rem;
     flex-shrink: 0;
-  }
-
-  /* Property chips */
-  .pdf-chips {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.375rem;
-    padding-left: 0.25rem;
-    margin-top: 0.25rem;
-    margin-bottom: 0.75rem;
-  }
-
-  .chip {
-    display: inline-flex;
-    align-items: stretch;
-    border: 1px solid var(--border-light);
-    border-radius: 9999px;
-    background: var(--bg-secondary);
-    font-size: 0.7rem;
-    white-space: nowrap;
-    overflow: hidden;
-  }
-
-  .chip-label {
-    display: flex;
-    align-items: center;
-    padding: 0.125rem 0.5rem 0.125rem 0.625rem;
-    color: var(--text-muted);
-    background: var(--bg-tertiary);
-    border-radius: 9999px 0 0 9999px;
-  }
-
-  .chip-divider {
-    width: 1px;
-    background: var(--border-light);
-  }
-
-  .chip-value {
-    display: flex;
-    align-items: center;
-    padding: 0.125rem 0.625rem 0.125rem 0.5rem;
-    color: var(--text-secondary);
   }
 
   /* Content area */

--- a/src/renderer/src/lib/media-properties.ts
+++ b/src/renderer/src/lib/media-properties.ts
@@ -1,0 +1,80 @@
+/**
+ * Media-specific property definitions and default chips configuration
+ * Used by MediaChips to provide property definitions for media notes (EPUB, PDF, Webpage)
+ */
+
+import type { PropertyDefinition, SourceFormat } from './automerge/types';
+
+/**
+ * Property definitions for EPUB notes.
+ * These complement whatever properties are defined on the note's type.
+ */
+export const EPUB_PROPERTIES: PropertyDefinition[] = [
+  { name: 'epubAuthor', type: 'string', description: 'Book author' },
+  { name: 'progress', type: 'number', description: 'Reading progress (0-100)' },
+  { name: 'lastRead', type: 'date', description: 'Last reading time' },
+  { name: 'highlights', type: 'number', description: 'Highlight count' }
+];
+
+/**
+ * Property definitions for PDF notes.
+ */
+export const PDF_PROPERTIES: PropertyDefinition[] = [
+  { name: 'pdfAuthor', type: 'string', description: 'Document author' },
+  { name: 'pages', type: 'string', description: 'Current/total pages' },
+  { name: 'progress', type: 'number', description: 'Reading progress (0-100)' },
+  { name: 'lastRead', type: 'date', description: 'Last reading time' },
+  { name: 'highlights', type: 'number', description: 'Highlight count' }
+];
+
+/**
+ * Property definitions for Webpage notes.
+ */
+export const WEBPAGE_PROPERTIES: PropertyDefinition[] = [
+  { name: 'webpageSiteName', type: 'string', description: 'Website name' },
+  { name: 'webpageAuthor', type: 'string', description: 'Article author' },
+  { name: 'progress', type: 'number', description: 'Reading progress (0-100)' },
+  { name: 'lastRead', type: 'date', description: 'Last reading time' },
+  { name: 'highlights', type: 'number', description: 'Highlight count' },
+  { name: 'source', type: 'string', description: 'Original source URL' }
+];
+
+/**
+ * Default editorChips configuration for media types when note type doesn't specify.
+ * This matches the current hardcoded behavior in media viewers.
+ */
+export const MEDIA_DEFAULT_CHIPS: Partial<Record<SourceFormat, string[]>> = {
+  epub: ['epubAuthor', 'progress', 'lastRead', 'highlights'],
+  pdf: ['pdfAuthor', 'pages', 'progress', 'lastRead', 'highlights'],
+  webpage: [
+    'webpageSiteName',
+    'webpageAuthor',
+    'progress',
+    'lastRead',
+    'highlights',
+    'source'
+  ]
+};
+
+/**
+ * Get media-specific property definitions for a source format.
+ */
+export function getMediaProperties(sourceFormat: SourceFormat): PropertyDefinition[] {
+  switch (sourceFormat) {
+    case 'epub':
+      return EPUB_PROPERTIES;
+    case 'pdf':
+      return PDF_PROPERTIES;
+    case 'webpage':
+      return WEBPAGE_PROPERTIES;
+    default:
+      return [];
+  }
+}
+
+/**
+ * Get default editorChips for a source format (when note type doesn't specify).
+ */
+export function getMediaDefaultChips(sourceFormat: SourceFormat): string[] {
+  return MEDIA_DEFAULT_CHIPS[sourceFormat] ?? ['updated'];
+}


### PR DESCRIPTION
## Summary
Media notes (EPUB, PDF, Webpage) now respect the note type's `editorChips` configuration instead of using hardcoded property displays. This allows users to customize which properties are shown by configuring their note types.

## Changes
- Extended EditorChips component to support computed values and additional property definitions
- Created MediaChips wrapper component for media viewers
- Updated EPUB, PDF, and Webpage viewers to use MediaChips
- Added media-properties registry with default configurations

## Test Plan
- Open an existing EPUB, PDF, or Webpage note and verify chips display correctly
- Assign a media note to a custom note type with editorChips configured
- Verify the configured chips are displayed instead of defaults
- Click expand button to verify all available fields are shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)