### PR TITLE
Fix list indentation accumulation bug

### DIFF
--- a/src/renderer/src/lib/textMeasurement.ts
+++ b/src/renderer/src/lib/textMeasurement.ts
@@ -44,7 +44,8 @@ export function measureMarkerWidths(editorElement: Element): MarkerWidths {
 
 function measureCodeMirrorLinePadding(editorElement: Element): number {
   // Look for existing .cm-line element to measure its actual padding
-  const cmLine = editorElement.querySelector('.cm-line');
+  // Exclude list-styled lines which have inflated padding from list decorations
+  const cmLine = editorElement.querySelector('.cm-line:not(.cm-list-marker-line)');
 
   if (cmLine) {
     const computedStyle = window.getComputedStyle(cmLine);


### PR DESCRIPTION
## Summary
Fixed a rendering bug where lists at the beginning of notes became progressively more indented each time the user switched away from the note and back.

## Root Cause
The `measureCodeMirrorLinePadding()` function was measuring the padding from list-decorated lines which include inflated styling, creating a feedback loop that accumulated indentation with each note switch.

## Solution
Updated the measurement to exclude list-styled lines using CSS selector `:not(.cm-list-marker-line)`, ensuring the true base padding is captured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)